### PR TITLE
fix: attempt to index field 'uv' (a nil value) on neovim < 0.10

### DIFF
--- a/lua/supermaven-nvim/binary/binary_handler.lua
+++ b/lua/supermaven-nvim/binary/binary_handler.lua
@@ -18,7 +18,7 @@ local BinaryLifecycle = {
   ignore_filetypes = {},
 }
 
-local timer = vim.uv.new_timer()
+local timer = loop.new_timer()
 timer:start(0, 25, vim.schedule_wrap(function()
   if BinaryLifecycle.wants_polling then
     BinaryLifecycle:poll_once()


### PR DESCRIPTION
Could not use the plugin because vim.uv is missing in neovim v0.9.5.