### PR TITLE
fix(completion_preview.lua): fix for cursor position for multi line completions

### DIFF
--- a/lua/supermaven-nvim/completion_preview.lua
+++ b/lua/supermaven-nvim/completion_preview.lua
@@ -128,10 +128,13 @@ function CompletionPreview.on_accept_suggestion()
 
     vim.api.nvim_feedkeys(vim.api.nvim_replace_termcodes("<Space><Left><Del>", true, false, true), "n", false)
     vim.lsp.util.apply_text_edits({{ range = range, newText = completion_text }}, vim.api.nvim_get_current_buf(), "utf-16")
-    local adjust_cursor = "<End>"
-    vim.api.nvim_feedkeys(vim.api.nvim_replace_termcodes(adjust_cursor, true, false, true), "n", false)
+
+    -- We need to update the cursor position based on the number of lines in the completion text
+    local lines = vim.split(completion_text, "\n", { plain = true })
+    local new_cursor_pos = {cursor[1] + #lines - 1, #lines[#lines] + 1}
+    vim.api.nvim_win_set_cursor(0, new_cursor_pos)
   else
-    vim.api.nvim_feedkeys(vim.api.nvim_replace_termcodes("<Tab>", true, false , true), "n", true) 
+    vim.api.nvim_feedkeys(vim.api.nvim_replace_termcodes("<Tab>", true, false , true), "n", true)
   end
 end
 

--- a/lua/supermaven-nvim/completion_preview.lua
+++ b/lua/supermaven-nvim/completion_preview.lua
@@ -129,9 +129,9 @@ function CompletionPreview.on_accept_suggestion()
     vim.api.nvim_feedkeys(vim.api.nvim_replace_termcodes("<Space><Left><Del>", true, false, true), "n", false)
     vim.lsp.util.apply_text_edits({{ range = range, newText = completion_text }}, vim.api.nvim_get_current_buf(), "utf-16")
 
-    -- We need to update the cursor position based on the number of lines in the completion text
-    local lines = vim.split(completion_text, "\n", { plain = true })
-    local new_cursor_pos = {cursor[1] + #lines - 1, #lines[#lines] + 1}
+    local lines = u.line_count(completion_text)
+    local last_line = u.get_last_line(completion_text)
+    local new_cursor_pos = {cursor[1] + lines , cursor[2] + #last_line + 1}
     vim.api.nvim_win_set_cursor(0, new_cursor_pos)
   else
     vim.api.nvim_feedkeys(vim.api.nvim_replace_termcodes("<Tab>", true, false , true), "n", true)

--- a/lua/supermaven-nvim/util.lua
+++ b/lua/supermaven-nvim/util.lua
@@ -161,8 +161,7 @@ function M.ends_with(str, suffix)
 end
 
 function M.get_utf8_length(str)
-  local byte_array = { str.byte(str, 1, -1) }
-  return #byte_array
+    return vim.fn.strlen(str)
 end
 
 function M.line_count(str)

--- a/lua/supermaven-nvim/util.lua
+++ b/lua/supermaven-nvim/util.lua
@@ -174,7 +174,7 @@ function M.line_count(str)
 end
 
 function M.get_last_line(str)
-  local last_line = ""
+  local last_line = str
   for i = #str, 1, -1 do
     local char = str:sub(i, i)
     if char == "\n" then

--- a/lua/supermaven-nvim/util.lua
+++ b/lua/supermaven-nvim/util.lua
@@ -161,7 +161,7 @@ function M.ends_with(str, suffix)
 end
 
 function M.get_utf8_length(str)
-    return vim.fn.strlen(str)
+  return #str
 end
 
 function M.line_count(str)


### PR DESCRIPTION
The main change is at the end of the `CompletionPreview.on_accept_suggestion()`, I calculate the new cursor position based on the number of lines in the `completion_text`.

So I just:
- Split the the completion_text into lines using vim.split()
- Then update the new cursor position using nvim_win_set_cursor()

Setting the cursor position using `nvim_win_set_cursor()` is a more standard approach, especially if users have certain keybindings for specific keys compared to PR #2.

This fixes Issue #2.