### PR TITLE
feat: allowing for `config = true` or `require(...).setup()`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,21 @@
+GREEN="\033[00;32m"
+RESTORE="\033[0m"
+
+# make the output of the message appear green
+define style_calls
+	$(eval $@_msg = $(1))
+	echo ${GREEN}${$@_msg}
+	echo ${RESTORE}
+endef
+
+.PHONY: test test-nvim test-all
+
+test:
+	@$(call style_calls,"Running vusted tests")
+	@SUPERMAVEN_TESTING="testing" vusted ./tests
+
+test-nvim:
+	@$(call style_calls,"Running tests using nvim")
+	@nvim --headless --noplugin -u ./tests/minimal_init.lua -c "PlenaryBustedDirectory ./tests {minimal_init = './tests/minimal_init.lua'}"
+
+test-all: test test-nvim

--- a/README.md
+++ b/README.md
@@ -13,11 +13,22 @@ require("lazy").setup({
     {
       "supermaven-inc/supermaven-nvim",
       config = function()
-        require("supermaven-nvim").setup({})
+        require("supermaven-nvim").setup()
       end,
+    },
+    { -- or this way
+      "supermaven-inc/supermaven-nvim",
+      config = true,
     },
 }, {})
 ```
+
+> [!NOTE]
+>
+> This is to use the default configuration of `supermaven-nvim`.
+>
+> If you want to customize the configuration, see the [Optional configuration](#optional-configuration)
+> section below.
 
 ### Optional configuration
 

--- a/lua/supermaven-nvim/config.lua
+++ b/lua/supermaven-nvim/config.lua
@@ -1,16 +1,16 @@
----@class SuperMavenKeymap
+---@class SupermavenKeymap
 ---@field accept_suggestion string: The keymap to accept the suggestion.
 ---@field clear_suggestion string: The keymap to clear the suggestion.
 ---@field accept_word string: The keymap to accept the word under the cursor.
 
----@class SuperMavenColor
+---@class SupermavenColor
 ---@field suggestion_color string|nil: The color of the suggestion.
 ---@field cterm string|nil: The color of the suggestion in the terminal.
 
----@class SuperMavenConfig
+---@class SupermavenConfig
 ---@field keymaps table<string, string>: The keymaps to use for the plugin.
 ---@field ignore_filetypes table<string, string>: The filetypes to ignore.
----@field color SuperMavenColor|nil: The color of the suggestion.
+---@field color SupermavenColor|nil: The color of the suggestion.
 
 local default_config = {
 	keymaps = {
@@ -23,15 +23,15 @@ local default_config = {
 
 M = {}
 
----@class SuperMavenConfig
----@field default_config SuperMavenConfig: The default configuration.
+---@class SupermavenConfig
+---@field default_config SupermavenConfig: The default configuration.
 M.default_config = default_config
 
----@class SuperMavenConfig
+---@class SupermavenConfig
 ---@field setup_config function: Sets up the configuration.
 --- Sets up the configuration with the default values and the given custom values.
----@param args SuperMavenConfig|nil
----@return SuperMavenConfig
+---@param args SupermavenConfig|nil
+---@return SupermavenConfig
 M.setup_config = function(args)
 	local config = vim.tbl_deep_extend("force", {}, default_config, args or {})
 	return config

--- a/lua/supermaven-nvim/config.lua
+++ b/lua/supermaven-nvim/config.lua
@@ -1,17 +1,40 @@
+---@class SuperMavenKeymap
+---@field accept_suggestion string: The keymap to accept the suggestion.
+---@field clear_suggestion string: The keymap to clear the suggestion.
+---@field accept_word string: The keymap to accept the word under the cursor.
+
+---@class SuperMavenColor
+---@field suggestion_color string|nil: The color of the suggestion.
+---@field cterm string|nil: The color of the suggestion in the terminal.
+
+---@class SuperMavenConfig
+---@field keymaps table<string, string>: The keymaps to use for the plugin.
+---@field ignore_filetypes table<string, string>: The filetypes to ignore.
+---@field color SuperMavenColor|nil: The color of the suggestion.
+
 local default_config = {
-  keymaps = {
-    accept_suggestion = "<Tab>",
-    clear_suggestion = "<C-]>",
-    accept_word = "<C-j>",
-  },
-  ignore_filetypes = {},
+	keymaps = {
+		accept_suggestion = "<Tab>",
+		clear_suggestion = "<C-]>",
+		accept_word = "<C-j>",
+	},
+	ignore_filetypes = {},
 }
 
 M = {}
 
+---@class SuperMavenConfig
+---@field default_config SuperMavenConfig: The default configuration.
+M.default_config = default_config
+
+---@class SuperMavenConfig
+---@field setup_config function: Sets up the configuration.
+--- Sets up the configuration with the default values and the given custom values.
+---@param args SuperMavenConfig|nil
+---@return SuperMavenConfig
 M.setup_config = function(args)
-  local config = vim.tbl_deep_extend("force", default_config, args)
-  return config
+	local config = vim.tbl_deep_extend("force", {}, default_config, args or {})
+	return config
 end
 
 return M

--- a/lua/supermaven-nvim/init.lua
+++ b/lua/supermaven-nvim/init.lua
@@ -4,14 +4,14 @@ local u = require("supermaven-nvim.util")
 local listener = require("supermaven-nvim.document_listener")
 local supermave_config = require("supermaven-nvim.config")
 
----@class SuperMaven
+---@class Supermaven
 M = {}
 
----@class SuperMaven
----@field config SuperMavenConfig
+---@class Supermaven
+---@field config SupermavenConfig
 M.config = {}
 
----@class SuperMaven
+---@class Supermaven
 ---@field setup function
 --- Sets up the plugin with the given a custom configuration (args)
 --- or the default configuration.
@@ -33,8 +33,8 @@ M.config = {}
 ---
 ---[link to the configuration section](https://github.com/supermaven-nvim/supermaven-nvim/blob/main/lua/supermaven-nvim/config.lua)
 ---
----@see SuperMavenConfig
----@param args SuperMavenConfig
+---@see SupermavenConfig
+---@param args SupermavenConfig
 M.setup = function(args)
   M.config = supermave_config.setup_config(args)
   if M.config.keymaps.accept_suggestion ~= nil then

--- a/lua/supermaven-nvim/init.lua
+++ b/lua/supermaven-nvim/init.lua
@@ -2,35 +2,64 @@ local binary = require("supermaven-nvim.binary.binary_handler")
 local completion_preview = require("supermaven-nvim.completion_preview")
 local u = require("supermaven-nvim.util")
 local listener = require("supermaven-nvim.document_listener")
-local config = require("supermaven-nvim.config")
+local supermave_config = require("supermaven-nvim.config")
 
+---@class SuperMaven
 M = {}
 
+---@class SuperMavenConfig
+---@field config SuperMavenConfig
+M.config = {}
+
+---@class SuperMaven
+---@field setup function
+--- Sets up the plugin with the given a custom configuration (args)
+--- or the default configuration.
+---
+--- The default configuration is:
+---
+--- ```lua
+--- require("supermaven-nvim").setup({
+---   keymaps = {
+---     accept_suggestion = "<Tab>",
+---     clear_suggestion = "<C-]>",
+---     accept_word = "<C-j>",
+---   },
+---   ignore_filetypes = {},
+--- })
+--- ```
+---
+---Or you can pass a custom configuration:
+---
+---[link to the configuration section](https://github.com/supermaven-nvim/supermaven-nvim/blob/main/lua/supermaven-nvim/config.lua)
+---
+---@see SuperMavenConfig
+---@param args SuperMavenConfig
 M.setup = function(args)
-  local config_settings = config.setup_config(args)
-  if config_settings.keymaps.accept_suggestion ~= nil then
-    local accept_suggestion_key = config_settings.keymaps.accept_suggestion
+  M.config = supermave_config.setup_config(args)
+  if M.config.keymaps.accept_suggestion ~= nil then
+    local accept_suggestion_key = M.config.keymaps.accept_suggestion
     vim.keymap.set('i', accept_suggestion_key, completion_preview.on_accept_suggestion, { noremap = true, silent = true })
   end
 
-  if config_settings.keymaps.accept_word ~= nil then
-    local accept_word_key = config_settings.keymaps.accept_word
+  if M.config.keymaps.accept_word ~= nil then
+    local accept_word_key = M.config.keymaps.accept_word
     vim.keymap.set('i', accept_word_key, completion_preview.on_accept_suggestion_word, { noremap = true, silent = true })
   end
 
-  if config_settings.keymaps.clear_suggestion ~= nil then
-    local clear_suggestion_key = config_settings.keymaps.clear_suggestion
+  if M.config.keymaps.clear_suggestion ~= nil then
+    local clear_suggestion_key = M.config.keymaps.clear_suggestion
     vim.keymap.set('i', clear_suggestion_key, completion_preview.on_dispose_inlay, { noremap = true, silent = true })
   end
-  binary:start_binary(config_settings.ignore_filetypes or {})
+  binary:start_binary(M.config.ignore_filetypes or {})
 
-  if config_settings.color and config_settings.color.suggestion_color and config_settings.color.cterm then
+  if M.config.color and M.config.color.suggestion_color and M.config.color.cterm then
     vim.api.nvim_create_autocmd({"VimEnter", "ColorScheme"}, {
       pattern = "*",
-      callback = function(event)
-        vim.api.nvim_set_hl(0, "SupermavenSuggestion", { 
-          fg = config_settings.color.suggestion_color,
-          ctermfg = config_settings.color.cterm,
+      callback = function(_)
+        vim.api.nvim_set_hl(0, "SupermavenSuggestion", {
+          fg = M.config.color.suggestion_color,
+          ctermfg = M.config.color.cterm,
         })
         completion_preview.suggestion_group = "SupermavenSuggestion"
       end

--- a/lua/supermaven-nvim/init.lua
+++ b/lua/supermaven-nvim/init.lua
@@ -7,7 +7,7 @@ local supermave_config = require("supermaven-nvim.config")
 ---@class SuperMaven
 M = {}
 
----@class SuperMavenConfig
+---@class SuperMaven
 ---@field config SuperMavenConfig
 M.config = {}
 

--- a/tests/minimal_init.lua
+++ b/tests/minimal_init.lua
@@ -1,0 +1,11 @@
+local plenary_dir = os.getenv("PLENARY_DIR") or "/tmp/plenary.nvim"
+local is_not_a_directory = vim.fn.isdirectory(plenary_dir) == 0
+if is_not_a_directory then
+	vim.fn.system({ "git", "clone", "https://github.com/nvim-lua/plenary.nvim", plenary_dir })
+end
+
+vim.opt.rtp:append(".")
+vim.opt.rtp:append(plenary_dir)
+
+vim.cmd("runtime plugin/plenary.vim")
+require("plenary.busted")

--- a/tests/supermaven-nvim/setup_spec.lua
+++ b/tests/supermaven-nvim/setup_spec.lua
@@ -1,0 +1,49 @@
+describe("setup", function()
+	it("should set up the plugin's user commands", function()
+		require("supermaven-nvim").setup()
+		local user_commands = vim.api.nvim_get_commands({})
+		-- User commands = SupermmaveUserFree
+		assert.are.not_same(user_commands["SupermavenUseFree"], nil, "SupermavenUseFree command should be set up")
+		assert.are.not_same(user_commands["SupermavenUsePro"], nil, "SupermavenUsePro command should be set up")
+		assert.are.not_same(user_commands["SupermavenLogout"], nil, "SupermavenLogout command should be set up")
+	end)
+
+	it("should set up the plugin with the default config", function()
+		require("supermaven-nvim").setup()
+		assert.are.same(require("supermaven-nvim").config, {
+			keymaps = {
+				accept_suggestion = "<Tab>",
+				clear_suggestion = "<C-]>",
+				accept_word = "<C-j>",
+			},
+			ignore_filetypes = {},
+		}, "default config should be set")
+	end)
+
+	it("should set up the plugin with a custom config", function()
+		require("supermaven-nvim").setup({
+			keymaps = {
+				accept_suggestion = "<C-j>",
+				clear_suggestion = "<C-k>",
+				accept_word = "<C-l>",
+			},
+			ignore_filetypes = { cpp = true },
+			color = {
+				suggestion_color = "#ffffff",
+				cterm = 244,
+			},
+		})
+		assert.are.same(require("supermaven-nvim").config, {
+			keymaps = {
+				accept_suggestion = "<C-j>",
+				clear_suggestion = "<C-k>",
+				accept_word = "<C-l>",
+			},
+			ignore_filetypes = { cpp = true },
+			color = {
+				suggestion_color = "#ffffff",
+				cterm = 244,
+			},
+		}, "custom config should be set")
+	end)
+end)

--- a/tests/supermaven-nvim/setup_spec.lua
+++ b/tests/supermaven-nvim/setup_spec.lua
@@ -1,49 +1,37 @@
-describe("setup", function()
-	it("should set up the plugin's user commands", function()
-		require("supermaven-nvim").setup()
-		local user_commands = vim.api.nvim_get_commands({})
-		-- User commands = SupermmaveUserFree
-		assert.are.not_same(user_commands["SupermavenUseFree"], nil, "SupermavenUseFree command should be set up")
-		assert.are.not_same(user_commands["SupermavenUsePro"], nil, "SupermavenUsePro command should be set up")
-		assert.are.not_same(user_commands["SupermavenLogout"], nil, "SupermavenLogout command should be set up")
-	end)
+describe("[supermaven-nvim tests]", function()
+	describe("setup", function()
+		it("should set up the plugin's user commands", function()
+			require("supermaven-nvim").setup()
+			local user_commands = vim.api.nvim_get_commands({})
+			-- User commands = SupermmaveUserFree
+			assert.are.not_same(user_commands["SupermavenUseFree"], nil, "SupermavenUseFree command should be set up")
+			assert.are.not_same(user_commands["SupermavenUsePro"], nil, "SupermavenUsePro command should be set up")
+			assert.are.not_same(user_commands["SupermavenLogout"], nil, "SupermavenLogout command should be set up")
+		end)
 
-	it("should set up the plugin with the default config", function()
-		require("supermaven-nvim").setup()
-		assert.are.same(require("supermaven-nvim").config, {
-			keymaps = {
-				accept_suggestion = "<Tab>",
-				clear_suggestion = "<C-]>",
-				accept_word = "<C-j>",
-			},
-			ignore_filetypes = {},
-		}, "default config should be set")
-	end)
+		it("should set up the plugin with the default config", function()
+			local actual = require("supermaven-nvim").setup()
+			local expected = require("supermaven-nvim.config").config
 
-	it("should set up the plugin with a custom config", function()
-		require("supermaven-nvim").setup({
-			keymaps = {
-				accept_suggestion = "<C-j>",
-				clear_suggestion = "<C-k>",
-				accept_word = "<C-l>",
-			},
-			ignore_filetypes = { cpp = true },
-			color = {
-				suggestion_color = "#ffffff",
-				cterm = 244,
-			},
-		})
-		assert.are.same(require("supermaven-nvim").config, {
-			keymaps = {
-				accept_suggestion = "<C-j>",
-				clear_suggestion = "<C-k>",
-				accept_word = "<C-l>",
-			},
-			ignore_filetypes = { cpp = true },
-			color = {
-				suggestion_color = "#ffffff",
-				cterm = 244,
-			},
-		}, "custom config should be set")
+			assert.are.same(actual, expected, "default config should be set")
+		end)
+
+		it("should set up the plugin with a custom config", function()
+			local actual = require("supermaven-nvim").setup({
+				keymaps = {
+					accept_suggestion = "<C-j>",
+					clear_suggestion = "<C-k>",
+					accept_word = "<C-l>",
+				},
+				ignore_filetypes = { cpp = true },
+				color = {
+					suggestion_color = "#89b4fa",
+					cterm = 177,
+				},
+			})
+			local expected = require("supermaven-nvim.config").config
+
+			assert.are.same(actual, expected, "custom config should be set")
+		end)
 	end)
 end)


### PR DESCRIPTION
# Changes description

With these changes it will allow for more user options when calling `setup`.

https://github.com/supermaven-inc/supermaven-nvim/blob/98c2821c985ec751df46c033c5494079dce61522/lua/supermaven-nvim/config.lua#L12-L15

With the changes, now it forces an `empty table` into the `default_config` into the `args` or an `empty table` if `args` are `nil`.

## Summary

- [x] added test suite to ensure the setup process
  - [x] creates user commands `:SupermavenUse{Free|Pro}` and `:SupermavenLogout`.
  - [x] sets up correctly with the default config, with `args = nil` and `args = default_config`.
  - [x] sets up correctly with the user config.
- [x] added `Makefile` to improve DX when testing.
  - [x] environment free testing with [vusted](https://github.com/notomo/vusted) with `make test`.
  - [x] Neovim environment testing with [plenary.nvim](https://github.com/nvim-lua/plenary.nvim) with `make test-nvim`.
- [x] Added type annotations to the changed files to improve typing variables and accessing table entries or calling functions.

<details>
<summary>Test results</summary>

```txt
Running vusted tests

ok 1 - setup should set up the plugin's user commands
ok 2 - setup should set up the plugin with the default config
ok 3 - setup should set up the plugin with a custom config
1..3


# Success: 3
Running tests using nvim

Starting...
Scheduling: ./tests/supermaven-nvim/setup_spec.lua

========================================
Testing:        /Users/aome/dev/nvim_plugins/supermaven-nvim/tests/supermaven-nvim/setup_spec.lua
Success ||      setup should set up the plugin's user commands
Success ||      setup should set up the plugin with the default config
Success ||      setup should set up the plugin with a custom config

Success:        3
Failed :        0
Errors :        0
========================================
```

</details>

The test suite could be added to **Github** workflows if needed. Example of test suite workflow on [freeze-code.nvim](https://github.com/AlejandroSuero/freeze-code.nvim/blob/main/.github/workflows/test.yml).