### PR TITLE
fix(#4): preventing `popup` from spawning multiple times

### DIFF
--- a/lua/supermaven-nvim/binary/binary_handler.lua
+++ b/lua/supermaven-nvim/binary/binary_handler.lua
@@ -446,6 +446,7 @@ function BinaryLifecycle:use_free_version()
     vim.notify("Loading Supermaven ...", vim.log.levels.WARN, { title = "Supermaven" })
     self.popup_should_open = true
     self.popups_opened = self.popups_opened + 1
+    self:close_popup()
   end
   local message = vim.json.encode({ kind = "use_free_version" }) .. "\n"
   loop.write(self.stdin, message) -- fails silently
@@ -466,6 +467,7 @@ function BinaryLifecycle:logout()
 end
 
 function BinaryLifecycle:use_pro()
+  self:close_popup()
   if self.activate_url ~= nil then
     print("Visit " .. self.activate_url .. " to set up Supermaven Pro")
     self.popup_should_open = true


### PR DESCRIPTION
# Changes made

- [x] Added control flags `popups_opened` and `popup_should_open` to the `BinaryLifecycle` class.
- [x] Added `q` and `<esc>` to close popup in an easier way.
- [x] Added `set nomodifiable` to popup's buffer to prevent editing.
- [x] Added state notifications when is `logging out` or `using a tier`.

Fixes #4

## Demo of the changes

https://github.com/supermaven-inc/supermaven-nvim/assets/71392160/6b3cd438-f587-4199-a601-d57285cf8600