### PR TITLE
feat(#18): add `silence_info` and created `logger` to write to a log file

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,9 +50,7 @@ require("supermaven-nvim").setup({
     suggestion_color = "#ffffff",
     cterm = 244,
   },
-  debug = false, -- set to true to enable debug logging
-  silence_info = false, -- set to true to silence info messages
-  log_level = "warn", -- set to "off" to disable logging completely
+  log_level = "info", -- set to "off" to disable logging completely
   disable_inline_completion = false, -- disables inline completion for use with cmp
   disable_keymaps = false -- disables built in keymaps for more manual control
 })

--- a/README.md
+++ b/README.md
@@ -171,4 +171,6 @@ api.is_running() -- returns true if supermaven-nvim is running
 api.use_free_version() -- switch to the free version
 api.use_pro() -- switch to the pro version
 api.logout() -- log out of supermaven
+api.show_log() -- show logs for supermaven-nvim
+api.clear_log() -- clear logs for supermaven-nvim
 ```

--- a/README.md
+++ b/README.md
@@ -38,7 +38,9 @@ require("supermaven-nvim").setup({
   color = {
     suggestion_color = "#ffffff",
     cterm = 244,
-  }
+  },
+  debug = false, -- set to true to enable debug logging
+  silence_info = false, -- set to true to silence info messages
 })
 ```
 
@@ -47,3 +49,5 @@ require("supermaven-nvim").setup({
 Upon starting supermaven-nvim, you will be prompted to either use the Free Tier with the command `:SupermavenUseFree` or to activate a Supermaven Pro subscription by following a link, which will connect your Supermaven account.
 
 If Supermaven is set up, you can use `:SupermavenLogout` to switch versions.
+
+You can also use `:SupermavenShowLog` to view the logged messages in `path/to/stdpath-cache/supermaven-nvim.log` if you encounter any issues. Or `:SupermavenClearLog` to clear the log file.

--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ require("supermaven-nvim").setup({
   },
   debug = false, -- set to true to enable debug logging
   silence_info = false, -- set to true to silence info messages
+  log_level = "warn", -- set to "off" to disable logging completely
 })
 ```
 

--- a/lua/supermaven-nvim/api.lua
+++ b/lua/supermaven-nvim/api.lua
@@ -1,5 +1,8 @@
 local binary = require("supermaven-nvim.binary.binary_handler")
 local listener = require("supermaven-nvim.document_listener")
+local log = require("supermaven-nvim.logger")
+
+local log_path = log:get_log_path()
 
 local M = {}
 
@@ -49,6 +52,22 @@ end
 
 M.logout = function()
   binary:logout()
+end
+
+M.show_log = function()
+    if log_path ~= nil then
+      vim.cmd(string.format(":e %s", log_path))
+    else
+      log:warn("No log file found to show!")
+    end
+end
+
+M.clear_log = function()
+    if log_path ~= nil then
+      vim.loop.fs_unlink(log_path)
+      else
+        log:warn("No log file found to remove!")
+    end
 end
 
 return M

--- a/lua/supermaven-nvim/api.lua
+++ b/lua/supermaven-nvim/api.lua
@@ -56,6 +56,7 @@ end
 
 M.show_log = function()
     if log_path ~= nil then
+      vim.cmd.tabnew()
       vim.cmd(string.format(":e %s", log_path))
     else
       log:warn("No log file found to show!")

--- a/lua/supermaven-nvim/api.lua
+++ b/lua/supermaven-nvim/api.lua
@@ -12,7 +12,9 @@ end
 
 M.start = function()
   if M.is_running() then
-    vim.notify("Supermaven is already running.", vim.log.levels.WARN)
+    log:warn("Supermaven is already running.")
+  else
+    log:trace("Starting Supermaven...")
   end
   binary:start_binary()
   listener.setup()
@@ -20,8 +22,10 @@ end
 
 M.stop = function()
   if not M.is_running() then
-    vim.notify("Supermaven is not running.", vim.log.levels.WARN)
+    log:warn("Supermaven is not running.")
     return
+  else
+    log:trace("Stopping Supermaven...")
   end
   listener.teardown()
   binary:stop_binary()

--- a/lua/supermaven-nvim/binary/binary_fetcher.lua
+++ b/lua/supermaven-nvim/binary/binary_fetcher.lua
@@ -1,3 +1,4 @@
+local log = require("supermaven-nvim.logger")
 local BinaryFetcher = {
   binary_path = nil,
   binary_url = nil,
@@ -40,7 +41,7 @@ function BinaryFetcher:discover_binary_url()
 
   local json = vim.fn.json_decode(response)
   if json == nil then
-    print("Error: Unable to find download URL for Supermaven binary")
+    log:error("Unable to find download URL for Supermaven binary")
     return nil
   end
 
@@ -55,7 +56,7 @@ function BinaryFetcher:fetch_binary()
   else
     local success = vim.fn.mkdir(self:local_binary_parent_path(), "p")
     if not success then
-      print("Error creating directory " .. self:local_binary_parent_path())
+      log:error("Error creating directory " .. self:local_binary_parent_path())
       return nil
     end
   end
@@ -65,7 +66,7 @@ function BinaryFetcher:fetch_binary()
     return nil
   end
 
-  print("Downloading Supermaven binary, please wait...")
+  log:info("Downloading Supermaven binary, please wait...")
   local platform = self:platform()
   local response = ""
   if platform == "windows" then
@@ -74,9 +75,9 @@ function BinaryFetcher:fetch_binary()
     response = vim.fn.system("curl -o " .. local_binary_path .. " " .. "'" .. url .. "'")
   end
   if vim.v.shell_error == 0 then
-    print("Downloaded binary sm-agent to " .. local_binary_path)
+    log:info("Downloaded binary sm-agent to " .. local_binary_path)
   else
-    print("Error: sm-agent download failed")
+    log:error("sm-agent download failed")
     return nil
   end
   vim.loop.fs_chmod(local_binary_path, 493)

--- a/lua/supermaven-nvim/commands.lua
+++ b/lua/supermaven-nvim/commands.lua
@@ -1,4 +1,5 @@
 local api = require("supermaven-nvim.api")
+local log = require("supermaven-nvim.logger")
 
 local M = {}
 
@@ -20,7 +21,7 @@ M.setup = function()
   end, {})
 
   vim.api.nvim_create_user_command("SupermavenStatus", function()
-    vim.notify(string.format("Supermaven is %s", api.is_running() and "running" or "not running"))
+    log:trace(string.format("Supermaven is %s", api.is_running() and "running" or "not running"))
   end, {})
 
   vim.api.nvim_create_user_command("SupermavenUseFree", function()

--- a/lua/supermaven-nvim/commands.lua
+++ b/lua/supermaven-nvim/commands.lua
@@ -34,6 +34,14 @@ M.setup = function()
   vim.api.nvim_create_user_command("SupermavenLogout", function()
     api.logout()
   end, {})
+
+	vim.api.nvim_create_user_command("SupermavenShowLog", function()
+    api.show_log()
+	end, {})
+
+  vim.api.nvim_create_user_command("SupermavenClearLog", function()
+    api.clear_log()
+  end, {})
 end
 
 return M

--- a/lua/supermaven-nvim/config.lua
+++ b/lua/supermaven-nvim/config.lua
@@ -7,7 +7,7 @@ local default_config = {
   ignore_filetypes = {},
   disable_inline_completion = false,
   disable_keymaps = false,
-  log_level = "warn",
+  log_level = "info",
 }
 
 local M = {

--- a/lua/supermaven-nvim/config.lua
+++ b/lua/supermaven-nvim/config.lua
@@ -1,17 +1,65 @@
 local default_config = {
-  keymaps = {
-    accept_suggestion = "<Tab>",
-    clear_suggestion = "<C-]>",
-    accept_word = "<C-j>",
-  },
-  ignore_filetypes = {},
+	keymaps = {
+		accept_suggestion = "<Tab>",
+		clear_suggestion = "<C-]>",
+		accept_word = "<C-j>",
+	},
+	ignore_filetypes = {},
+	debug = false,
+	silence_info = false,
+	log_level = "warn",
+	__setup = false,
 }
 
-M = {}
+local M = {}
+
+local config = vim.deepcopy(default_config)
+
+local wanted_type = function(key)
+	if vim.startswith(key, "__") then
+		return "nil", true
+	end
+	return type(default_config[key]), true
+end
+
+local validate_config = function(args)
+	local to_check, validated = {}, {}
+
+	---@diagnostic disable-next-line: unused-function
+	local function get_wanted_type(config_table)
+		for key in pairs(config_table) do
+			local wanted, optional = wanted_type(key)
+			to_check[key] = { args[key], wanted, optional }
+			validated[key] = args[key]
+		end
+	end
+
+	get_wanted_type(config)
+	vim.validate(to_check)
+	return validated
+end
+
+M.get_config = function()
+	return config
+end
+
+M.__set = function(new_config)
+	config = vim.tbl_deep_extend("force", {}, config, new_config or {})
+end
+
+M.reset_config = function()
+	config = vim.deepcopy(default_config)
+end
 
 M.setup_config = function(args)
-  local config = vim.tbl_deep_extend("force", default_config, args)
-  return config
+	if config.__setup then
+		return
+	end
+	local validated_config = validate_config(args)
+
+	config = vim.tbl_extend("force", config, validated_config)
+
+	config.__setup = true
 end
 
 return M

--- a/lua/supermaven-nvim/config.lua
+++ b/lua/supermaven-nvim/config.lua
@@ -1,9 +1,16 @@
+---@class SupermavenConfig
+---@field log_level LogLevel
+---@field ignore_filetypes string[]
 local default_config = {
 	keymaps = {
 		accept_suggestion = "<Tab>",
 		clear_suggestion = "<C-]>",
 		accept_word = "<C-j>",
 	},
+  color = {
+    suggestion_color = "#ffffff",
+    cterm_color = 244,
+  },
 	ignore_filetypes = {},
 	debug = false,
 	silence_info = false,
@@ -13,8 +20,12 @@ local default_config = {
 
 local M = {}
 
-local config = vim.deepcopy(default_config)
+local config = default_config
 
+--- Get the type of the value
+---@param key string: key in the config table
+---@return string: type of the value
+---@return boolean: whether the value is optional
 local wanted_type = function(key)
 	if vim.startswith(key, "__") then
 		return "nil", true
@@ -22,6 +33,9 @@ local wanted_type = function(key)
 	return type(default_config[key]), true
 end
 
+--- Validate the config table
+---@param args table: config table
+---@return table: validated config table
 local validate_config = function(args)
 	local to_check, validated = {}, {}
 
@@ -39,18 +53,29 @@ local validate_config = function(args)
 	return validated
 end
 
+---@class SupermavenConfig
+---@field get_config function: SupermavenConfig -> table
+--- Get the config table
+---@return SupermavenConfig: config table
 M.get_config = function()
 	return config
 end
 
+--- Set the config table
+---@param new_config SupermavenConfig: config table
 M.__set = function(new_config)
 	config = vim.tbl_deep_extend("force", {}, config, new_config or {})
 end
 
+--- Reset the config table
+--- This is useful when you want to change the config table
+--- without having to restart Neovim.
 M.reset_config = function()
-	config = vim.deepcopy(default_config)
+	config = default_config
 end
 
+--- Set the config table
+---@param args SupermavenConfig: config table
 M.setup_config = function(args)
 	if config.__setup then
 		return

--- a/lua/supermaven-nvim/init.lua
+++ b/lua/supermaven-nvim/init.lua
@@ -1,8 +1,9 @@
 local binary = require("supermaven-nvim.binary.binary_handler")
 local completion_preview = require("supermaven-nvim.completion_preview")
-local u = require("supermaven-nvim.util")
-local listener = require("supermaven-nvim.document_listener")
+local _u = require("supermaven-nvim.util")
+local _listener = require("supermaven-nvim.document_listener")
 local config = require("supermaven-nvim.config")
+local log = require("supermaven-nvim.logger")
 
 local M = {}
 
@@ -59,8 +60,22 @@ M.setup = function(args)
 	end
 
 	vim.api.nvim_create_user_command("SupermavenShowLog", function()
-		vim.cmd(string.format(":e %s", require("supermaven-nvim.logger"):get_log_path()))
+    local log_path = require("supermaven-nvim.logger"):get_log_path()
+    if log_path ~= nil then
+      vim.cmd(string.format(":e %s", log_path))
+    else
+      log:warn("No log file found to show!")
+    end
 	end, {})
+
+  vim.api.nvim_create_user_command("SupermavenClearLog", function()
+    local log_path = require("supermaven-nvim.logger"):get_log_path()
+    if log_path ~= nil then
+      vim.loop.fs_unlink(log_path)
+      else
+        log:warn("No log file found to remove!")
+    end
+  end, {})
 end
 
 return M

--- a/lua/supermaven-nvim/init.lua
+++ b/lua/supermaven-nvim/init.lua
@@ -4,38 +4,63 @@ local u = require("supermaven-nvim.util")
 local listener = require("supermaven-nvim.document_listener")
 local config = require("supermaven-nvim.config")
 
-M = {}
+local M = {}
 
 M.setup = function(args)
-  local config_settings = config.setup_config(args)
-  if config_settings.keymaps.accept_suggestion ~= nil then
-    local accept_suggestion_key = config_settings.keymaps.accept_suggestion
-    vim.keymap.set('i', accept_suggestion_key, completion_preview.on_accept_suggestion, { noremap = true, silent = true })
-  end
+	if config.get_config().__setup then
+		return
+	end
 
-  if config_settings.keymaps.accept_word ~= nil then
-    local accept_word_key = config_settings.keymaps.accept_word
-    vim.keymap.set('i', accept_word_key, completion_preview.on_accept_suggestion_word, { noremap = true, silent = true })
-  end
+	args = args or {}
+	config.setup_config(args)
+	config = config.get_config()
+	if config.keymaps.accept_suggestion ~= nil then
+		local accept_suggestion_key = config.keymaps.accept_suggestion
+		vim.keymap.set(
+			"i",
+			accept_suggestion_key,
+			completion_preview.on_accept_suggestion,
+			{ noremap = true, silent = true }
+		)
+	end
 
-  if config_settings.keymaps.clear_suggestion ~= nil then
-    local clear_suggestion_key = config_settings.keymaps.clear_suggestion
-    vim.keymap.set('i', clear_suggestion_key, completion_preview.on_dispose_inlay, { noremap = true, silent = true })
-  end
-  binary:start_binary(config_settings.ignore_filetypes or {})
+	if config.keymaps.accept_word ~= nil then
+		local accept_word_key = config.keymaps.accept_word
+		vim.keymap.set(
+			"i",
+			accept_word_key,
+			completion_preview.on_accept_suggestion_word,
+			{ noremap = true, silent = true }
+		)
+	end
 
-  if config_settings.color and config_settings.color.suggestion_color and config_settings.color.cterm then
-    vim.api.nvim_create_autocmd({"VimEnter", "ColorScheme"}, {
-      pattern = "*",
-      callback = function(event)
-        vim.api.nvim_set_hl(0, "SupermavenSuggestion", { 
-          fg = config_settings.color.suggestion_color,
-          ctermfg = config_settings.color.cterm,
-        })
-        completion_preview.suggestion_group = "SupermavenSuggestion"
-      end
-    })
-  end
+	if config.keymaps.clear_suggestion ~= nil then
+		local clear_suggestion_key = config.keymaps.clear_suggestion
+		vim.keymap.set(
+			"i",
+			clear_suggestion_key,
+			completion_preview.on_dispose_inlay,
+			{ noremap = true, silent = true }
+		)
+	end
+	binary:start_binary(config.ignore_filetypes or {})
+
+	if config.color and config.color.suggestion_color and config.color.cterm then
+		vim.api.nvim_create_autocmd({ "VimEnter", "ColorScheme" }, {
+			pattern = "*",
+			callback = function(event)
+				vim.api.nvim_set_hl(0, "SupermavenSuggestion", {
+					fg = config.color.suggestion_color,
+					ctermfg = config.color.cterm,
+				})
+				completion_preview.suggestion_group = "SupermavenSuggestion"
+			end,
+		})
+	end
+
+	vim.api.nvim_create_user_command("SupermavenShowLog", function()
+		vim.cmd(string.format(":e %s", require("supermaven-nvim.logger"):get_log_path()))
+	end, {})
 end
 
 return M

--- a/lua/supermaven-nvim/init.lua
+++ b/lua/supermaven-nvim/init.lua
@@ -40,24 +40,6 @@ M.setup = function(args)
 
   commands.setup()
 
-	vim.api.nvim_create_user_command("SupermavenShowLog", function()
-    local log_path = require("supermaven-nvim.logger"):get_log_path()
-    if log_path ~= nil then
-      vim.cmd(string.format(":e %s", log_path))
-    else
-      log:warn("No log file found to show!")
-    end
-	end, {})
-
-  vim.api.nvim_create_user_command("SupermavenClearLog", function()
-    local log_path = require("supermaven-nvim.logger"):get_log_path()
-    if log_path ~= nil then
-      vim.loop.fs_unlink(log_path)
-      else
-        log:warn("No log file found to remove!")
-    end
-  end, {})
-
   local cmp_ok, cmp = pcall(require, "cmp")
   if cmp_ok then
     local cmp_source = require("supermaven-nvim.cmp")

--- a/lua/supermaven-nvim/logger.lua
+++ b/lua/supermaven-nvim/logger.lua
@@ -33,11 +33,18 @@ end
 function log:write_log_file(level, msg)
 	local log_path = log:get_log_path()
 	if log_path == nil then
-		return
+    -- TODO: create log file
+    log_path = join_path(vim.fn.stdpath("cache"), "supermaven-nvim.log")
+    local file = io.open(log_path, "a")
+    if file == nil then
+      self:error("Failed to create log file: " .. log_path)
+      return
+    end
+    file:close()
 	end
 	local file = io.open(log_path, "a")
 	if file == nil then
-		vim.api.nvim_err_writeln("Failed to open log file: " .. log_path)
+		self:error("Failed to open log file: " .. log_path)
 		return
 	end
 	file:write(string.format("[%-6s %s] %s\n", level:upper(), os.date(), msg))
@@ -48,7 +55,7 @@ end
 ---@param level LogLevel: The log level
 ---@param msg string: The log message
 function log:add_entry(level, msg)
-	local conf = c.get_config()
+	local conf = c.config
 	if self.__log_file == nil then
 		self.__log_file = create_log_file()
 	end

--- a/lua/supermaven-nvim/logger.lua
+++ b/lua/supermaven-nvim/logger.lua
@@ -9,9 +9,9 @@ local log = {}
 local join_path = function(...)
 	local is_windows = vim.loop.os_uname().version:match("Windows") -- could be "Windows" or "Windows_NT"
 	local path_sep = is_windows and "\\" or "/"
-  if vim.version().minor >= 10 then
-    return table.concat(vim.iter({ ... }):flatten():totable(), path_sep):gsub(path_sep .. "+", path_sep)
-  end
+	if vim.version().minor >= 10 then
+		return table.concat(vim.iter({ ... }):flatten():totable(), path_sep):gsub(path_sep .. "+", path_sep)
+	end
 	return table.concat(vim.tbl_flatten({ ... }), path_sep):gsub(path_sep .. "+", path_sep)
 end
 
@@ -36,8 +36,8 @@ end
 function log:write_log_file(level, msg)
 	local log_path = log:get_log_path()
 	if log_path == nil then
-    create_log_file()
-    return
+		create_log_file()
+		return
 	end
 	local file = io.open(log_path, "a")
 	if file == nil then
@@ -59,7 +59,7 @@ function log:add_entry(level, msg)
 
 	if not self.__notify_fmt then
 		self.__notify_fmt = function(message)
-			return string.format(message)
+			return string.format(string.format("[supermaven-nvim] %s", message))
 		end
 	end
 
@@ -68,19 +68,9 @@ function log:add_entry(level, msg)
 	end
 
 	self:write_log_file(level, msg)
-	if level == "info" then
-		print(self.__notify_fmt(string.format("[supermaven-nvim] INFO: %s", msg)))
+	if level ~= "error" and level ~= "warn" then
+		print(self.__notify_fmt(msg))
 	end
-  if not conf.silence_info then
-    if level == "trace" then
-      print(self.__notify_fmt(string.format("[supermaven-nvim] TRACE: %s", msg)))
-    end
-  end
-  if conf.debug then
-    if level == "debug" then
-      print(self.__notify_fmt(string.format("[supermaven-nvim] DEBUG: %s", msg)))
-    end
-  end
 end
 
 --- Returns the path to the log file
@@ -105,7 +95,7 @@ end
 ---@param msg string: The log message
 function log:warn(msg)
 	self:add_entry("warn", msg)
-	vim.api.nvim_err_writeln(self.__notify_fmt(msg))
+	vim.api.nvim_notify(self.__notify_fmt(msg), vim.log.levels.WARN, { title = "Supermaven" })
 end
 
 --- Logs an error message to the log file
@@ -113,7 +103,7 @@ end
 ---@param msg string: The log message
 function log:error(msg)
 	self:add_entry("error", msg)
-	vim.api.nvim_err_writeln(self.__notify_fmt(msg))
+	vim.api.nvim_notify(self.__notify_fmt(msg), vim.log.levels.ERROR, { title = "Supermaven" })
 end
 
 --- Logs an informational message to the log file

--- a/lua/supermaven-nvim/logger.lua
+++ b/lua/supermaven-nvim/logger.lua
@@ -1,0 +1,113 @@
+---@diagnostic disable: missing-parameter
+local c = require("supermaven-nvim.config")
+
+---@class Log
+local log = {}
+
+local join_path = function(...)
+	local is_windows = vim.loop.os_uname().version:match("Windows") -- could be "Windows" or "Windows_NT"
+	local path_sep = is_windows and "\\" or "/"
+	return table.concat(vim.tbl_flatten({ ... }), path_sep):gsub(path_sep .. "+", path_sep)
+end
+
+--- Creates a log file if it doesn't exist
+local create_log_file = function()
+	local log_path = log:get_log_path()
+	if log_path ~= nil then
+		return
+	end
+	log_path = join_path(vim.fn.stdpath("cache"), "supermaven-nvim.log")
+	local file = io.open(log_path, "a")
+	if file == nil then
+		vim.api.nvim_err_writeln("Failed to create log file: " .. log_path)
+		return
+	end
+	file:close()
+end
+
+function log:write_log_file(level, msg)
+	local log_path = log:get_log_path()
+	if log_path == nil then
+		return
+	end
+	local file = io.open(log_path, "a")
+	if file == nil then
+		vim.api.nvim_err_writeln("Failed to open log file: " .. log_path)
+		return
+	end
+	file:write(string.format("[%-6s %s] %s\n", level:upper(), os.date(), msg))
+	file:close()
+end
+
+function log:add_entry(level, msg)
+	if msg == nil then
+		print("received nil message")
+		return
+	end
+	local conf = c.get_config()
+	if self.__log_file == nil then
+		self.__log_file = create_log_file()
+	end
+
+	if not self.__notify_fmt then
+		self.__notify_fmt = function(message)
+			return string.format(message)
+		end
+	end
+
+	if conf.log_level == "off" then
+		return
+	end
+
+	self:write_log_file(level, msg)
+	if level == "info" then
+		print(self.__notify_fmt(string.format("[supermaven-nvim] INFO: %s", msg)))
+	end
+  if not conf.silence_info then
+    if level == "trace" then
+      print(self.__notify_fmt(string.format("[supermaven-nvim] TRACE: %s", msg)))
+    end
+  end
+  if conf.debug then
+    if level == "debug" then
+      print(self.__notify_fmt(string.format("[supermaven-nvim] DEBUG: %s", msg)))
+    end
+  end
+end
+
+function log:get_log_path()
+	local log_path = join_path(vim.fn.stdpath("cache"), "supermaven-nvim.log")
+	if vim.fn.filereadable(log_path) == 0 then
+		return nil
+	end
+	return log_path
+end
+
+function log:log(msg)
+	self:add_entry("log", msg)
+end
+
+function log:warn(msg)
+	self:add_entry("warn", msg)
+	vim.api.nvim_err_writeln(self.__notify_fmt(msg))
+end
+
+function log:error(msg)
+	self:add_entry("error", msg)
+	vim.api.nvim_err_writeln(self.__notify_fmt(msg))
+end
+
+function log:info(msg)
+	self:add_entry("info", msg)
+end
+
+function log:debug(msg)
+	self:add_entry("debug", msg)
+end
+
+function log:trace(msg)
+	self:add_entry("trace", msg)
+end
+
+setmetatable({}, log)
+return log

--- a/lua/supermaven-nvim/logger.lua
+++ b/lua/supermaven-nvim/logger.lua
@@ -4,6 +4,8 @@ local c = require("supermaven-nvim.config")
 ---@class Log
 local log = {}
 
+---@alias LogLevel "off" | "trace" | "debug" | "info" | "warn" | "error" | "log"
+
 local join_path = function(...)
 	local is_windows = vim.loop.os_uname().version:match("Windows") -- could be "Windows" or "Windows_NT"
 	local path_sep = is_windows and "\\" or "/"
@@ -25,6 +27,9 @@ local create_log_file = function()
 	file:close()
 end
 
+--- Writes a log entry to the log file
+---@param level LogLevel: The log level
+---@param msg string: The log message
 function log:write_log_file(level, msg)
 	local log_path = log:get_log_path()
 	if log_path == nil then
@@ -39,11 +44,10 @@ function log:write_log_file(level, msg)
 	file:close()
 end
 
+--- Adds log entry to the log file
+---@param level LogLevel: The log level
+---@param msg string: The log message
 function log:add_entry(level, msg)
-	if msg == nil then
-		print("received nil message")
-		return
-	end
 	local conf = c.get_config()
 	if self.__log_file == nil then
 		self.__log_file = create_log_file()
@@ -75,6 +79,8 @@ function log:add_entry(level, msg)
   end
 end
 
+--- Returns the path to the log file
+---@return string|nil: The path to the log file or nil if it doesn't exist
 function log:get_log_path()
 	local log_path = join_path(vim.fn.stdpath("cache"), "supermaven-nvim.log")
 	if vim.fn.filereadable(log_path) == 0 then
@@ -83,28 +89,56 @@ function log:get_log_path()
 	return log_path
 end
 
+--- Logs a message to the log file
+---@example log:log("Hello, world!")
+---@param msg string: The log message
 function log:log(msg)
 	self:add_entry("log", msg)
 end
 
+--- Logs a warning message to the log file
+---@example log:warn("Something went wrong!")
+---@param msg string: The log message
 function log:warn(msg)
 	self:add_entry("warn", msg)
 	vim.api.nvim_err_writeln(self.__notify_fmt(msg))
 end
 
+--- Logs an error message to the log file
+---@example log:error("Something went wrong!")
+---@param msg string: The log message
 function log:error(msg)
 	self:add_entry("error", msg)
 	vim.api.nvim_err_writeln(self.__notify_fmt(msg))
 end
 
+--- Logs an informational message to the log file
+---
+--- This is the level use to log information to the user as default.
+---@example log:info("Something happened!")
+---@param msg string: The log message
 function log:info(msg)
 	self:add_entry("info", msg)
 end
 
+--- Logs a debug message to the log file
+---
+--- Used to keep track of the execution of the plugin and extra information.
+---
+--- Only visible if the `debug` option is set to `true`.
+---@example log:debug("Debugging...")
+---@param msg string: The log message
 function log:debug(msg)
 	self:add_entry("debug", msg)
 end
 
+--- Logs a trace message to the log file
+---
+--- Used to keep track of the execution of the plugin.
+---
+--- Only visible if the `silence_info` option is set to `false`.
+---@example log:trace("Tracing...")
+---@param msg string: The log message
 function log:trace(msg)
 	self:add_entry("trace", msg)
 end

--- a/lua/supermaven-nvim/textual.lua
+++ b/lua/supermaven-nvim/textual.lua
@@ -1,5 +1,5 @@
 local u = require("supermaven-nvim.util")
-M = {}
+local M = {}
 
 local function find_first_non_empty_newline(s)
   local seen_non_whitespace = false
@@ -110,7 +110,7 @@ local function finish_completion(output, deletion, dedent, params)
         is_incomplete = false,
       }
     end
-    
+
     if not is_all_whitespace_and_closing_paren(params.line_after_cursor) then
       return nil
     end
@@ -128,7 +128,7 @@ local function finish_completion(output, deletion, dedent, params)
       }
     end
   end
-  
+
   return nil
 end
 
@@ -165,7 +165,7 @@ function M.derive_completion(completion, completion_params)
   if index ~= nil then
     output = output:sub(1, index)
   end
-  
+
   return finish_completion(output, deletion, dedent, completion_params)
 end
 

--- a/lua/supermaven-nvim/util.lua
+++ b/lua/supermaven-nvim/util.lua
@@ -1,8 +1,5 @@
-M = {}
-
-function M.print(msg)
-  vim.api.nvim_out_write(msg .. "\n")
-end
+local log = require("supermaven-nvim.logger")
+local M = {}
 
 local function compute_lps(pattern, lps)
   local length = 0
@@ -146,9 +143,9 @@ end
 
 function M.print_table(t, message)
   if message == nil then
-    print(vim.inspect(t) .. "\n")
+    log:info(vim.inspect(t) .. "\n")
   else
-    print(message .. ": " .. vim.inspect(t) .. "\n")
+    log:info(message .. ": " .. vim.inspect(t) .. "\n")
   end
 end
 


### PR DESCRIPTION
# Changes made

- [x] Added `logger` inspired by [none-ls](https://github.com/nvim-tools/none-ls.nvim) but without the use of [plenary.nvim](https://github.com/nvim-lua/plenary.nvim).
- [x] Made changes to the config to ease the use of a logger and validate the config and add user level settings to control when and what to show.
- [x] Changed the files that printed information to use `logger` with the level warning.
- [x] Made corresponding changes in the `README`.

## Demo of the changes

- With `silence_info` and `debug` on:

https://github.com/supermaven-inc/supermaven-nvim/assets/71392160/0be8797b-d6fa-4cb2-b6bd-beae5c57539b

- With `silence_info` and `debug` off:

https://github.com/supermaven-inc/supermaven-nvim/assets/71392160/d3300bde-9a8d-420d-9dd3-3a85187f479a

## How to use the logger

1. Import the logger `local log = require("supermaven-nvim.logger")`.
2. Decide which level of information you want the user to see.
  - Levels:
    - "error": Always shows.
    - "warn": Always shows.
    - "info": Always shows. (like `print`)
    - "debug": shows if `debug` is true.
    - "trace": shows if `silence_info` is true.
    - "off": logger turned off completely `log_level` option is set too `"off"`.
3. If you have them set to `debug = true` or/and silenced info, `:SupermavenShowLog` to show the log file with timestamps and the level off error.
4. If you want to reset or clear the log file, `:SupermavenClearLog`.

Closes #18
Closes #42