### PR TITLE
feature: added nvim-cmp source registration and option to disable built in inline suggestions

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,16 +50,14 @@ require("supermaven-nvim").setup({
     suggestion_color = "#ffffff",
     cterm = 244,
   },
-  disable_inline_completion = false -- disables inline completion for use with cmp
-
+  disable_inline_completion = false, -- disables inline completion for use with cmp
+  disable_keymaps = false -- disables built in keymaps for more manual control
 })
 ```
 
 ### Using with nvim-cmp
 
-If you are using nvim-cmp, you can use the `supermaven` source by adding the following to your `cmp.setup()` function:
-
-Supermaven's cmp source is registered by default and can be used by adding the following to your `cmp.setup()` function:
+If you are using nvim-cmp, you can use the `supermaven` source (which is registered by default) by adding the following to your `cmp.setup()` function:
 
 ```lua
 -- cmp.lua
@@ -101,6 +99,33 @@ cmp.setup {
   }
   ...
 }
+```
+
+### Programatically checking and accepting suggestions
+
+Alternatively, you can also check if there is an active suggestion and accept it programatically.
+
+For example:
+
+```lua
+require("supermaven-nvim").setup({
+  disable_keymaps = true
+})
+
+...
+
+M.expand = function(fallback)
+  local luasnip = require('luasnip')
+  local suggestion = require('supermaven-nvim.completion_preview')
+
+  if luasnip.expandable() then
+    luasnip.expand()
+  elseif suggestion.has_suggestion() then
+    suggestion.on_accept_suggestion()
+  else
+    fallback()
+  end
+end
 ```
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -19,6 +19,17 @@ require("lazy").setup({
 }, {})
 ```
 
+### Using [packer.nvim](https://github.com/wbthomason/packer.nvim)
+
+```lua
+use {
+  "supermaven-inc/supermaven-nvim",
+  config = function()
+    require("supermaven-nvim").setup({})
+  end,
+}
+```
+
 ### Optional configuration
 
 By default, supermaven-nvim will use the `<Tab>` and `<C-]>` keymaps to accept and clear suggestions. You can change these keymaps by passing a `keymaps` table to the .setup({}) function. Also in this table is `accept_word`, which allows partially accepting a completion, up to the end of the next word. By default this keymap is set to `<C-j>`.
@@ -38,8 +49,58 @@ require("supermaven-nvim").setup({
   color = {
     suggestion_color = "#ffffff",
     cterm = 244,
-  }
+  },
+  disable_inline_completion = false -- disables inline completion for use with cmp
+
 })
+```
+
+### Using with nvim-cmp
+
+If you are using nvim-cmp, you can use the `supermaven` source by adding the following to your `cmp.setup()` function:
+
+Supermaven's cmp source is registered by default and can be used by adding the following to your `cmp.setup()` function:
+
+```lua
+-- cmp.lua
+cmp.setup {
+  ...
+  sources = {
+    { name = "supermaven" },
+  }
+  ...
+}
+```
+
+It also has a builtin highlight group CmpItemKindSupermaven. To add an icon to Supermaven for lspkind, simply add Supermaven to your lspkind symbol map.
+
+```lua
+-- lspkind.lua
+local lspkind = require("lspkind")
+lspkind.init({
+  symbol_map = {
+    Supermaven = "",
+  },
+})
+
+vim.api.nvim_set_hl(0, "CmpItemKindSupermaven", {fg ="#6CC644"})
+```
+
+Alternatively, you can add Supermaven to the lspkind symbol_map within the cmp format function.
+
+```lua
+-- cmp.lua
+cmp.setup {
+  ...
+  formatting = {
+    format = lspkind.cmp_format({
+      mode = "symbol",
+      max_width = 50,
+      symbol_map = { Supermaven = "" }
+    })
+  }
+  ...
+}
 ```
 
 ## Usage

--- a/lua/supermaven-nvim/cmp.lua
+++ b/lua/supermaven-nvim/cmp.lua
@@ -1,0 +1,117 @@
+local CompletionPreview = require("supermaven-nvim.completion_preview")
+-- local u = require("supermaven-nvim.util")
+
+local source = { executions = {}, }
+
+local label_text = function(text)
+  local shorten = function(str)
+    local short_prefix = string.sub(str, 0, 20)
+    local short_suffix = string.sub(str, string.len(str) - 15, string.len(str))
+    local delimiter = " ... "
+    return short_prefix .. delimiter .. short_suffix
+  end
+  text = text:gsub("^%s*", "")
+  return string.len(text) > 40 and shorten(text) or text
+end
+
+function source.get_trigger_characters()
+  return { '*' }
+end
+
+function source.get_keyword_pattern()
+  return '.'
+end
+
+function source.is_available()
+  return true
+end
+
+function source.resolve(self, completion_item, callback)
+  for _, fn in ipairs(self.executions) do
+    completion_item = fn(completion_item)
+  end
+
+  callback(completion_item)
+end
+
+function source.execute(self, completion_item, callback)
+  CompletionPreview:dispose_inlay()
+
+  callback(completion_item)
+end
+
+function source.complete(self, params, callback)
+  local inlay_instance = CompletionPreview:get_inlay_instance()
+
+  if inlay_instance == nil or inlay_instance.is_active == false then
+    callback({
+      isIncomplete = true,
+      items = {},
+    })
+    return
+  end
+
+  -- local context         = params.context
+  local cursor          = vim.api.nvim_win_get_cursor(0)
+
+  local range           = {
+    start = {
+      line = cursor[1] - 1,
+      -- character = math.max(cursor[2] - inlay_instance.prior_delete, 0),
+      character = vim.fn.col("0")
+    },
+    ["end"] = {
+      line = cursor[1] - 1,
+      character = vim.fn.col("$")
+    }
+  }
+
+  local completion_text = (inlay_instance.line_before_cursor) .. inlay_instance.completion_text
+  local preview_text    = completion_text
+  local label           = label_text(vim.split(completion_text, "\n", { plain = true })[1])
+  -- local label           = u.trim_start(vim.split(completion_text, "\n", { plain = true })[1])
+
+  -- print("Completion label:", label)
+
+  local items           = {
+    {
+      label = label,
+      kind = 1,
+      score = 100,
+      filterText = nil,
+      cmp = {
+        kind_hl_group = "CmpItemKindSupermaven",
+        kind_text = 'Supermaven',
+      },
+      textEdit = {
+        newText = completion_text,
+        insert = range,
+        replace = range,
+      },
+      documentation = {
+        kind = "markdown",
+        value = "```" ..
+            vim.bo.filetype ..
+            "\n" .. preview_text .. "\n```"
+      },
+      dup = 0
+    }
+  }
+
+  return callback({
+    isIncomplete = false,
+    items = items
+  })
+end
+
+function source.new(client, opts)
+  local self = setmetatable({
+    timer = vim.loop.new_timer()
+  }, { __index = source })
+
+  self.client = client
+
+  return self
+end
+
+return source

--- a/lua/supermaven-nvim/cmp.lua
+++ b/lua/supermaven-nvim/cmp.lua
@@ -3,13 +3,18 @@ local CompletionPreview = require("supermaven-nvim.completion_preview")
 
 local source = { executions = {}, }
 
-local label_text = function(text)
+local label_text = function(text, lines)
+  if lines > 1 then
+    text = text .. " ~"
+  end
+
   local shorten = function(str)
     local short_prefix = string.sub(str, 0, 20)
     local short_suffix = string.sub(str, string.len(str) - 15, string.len(str))
     local delimiter = " ... "
     return short_prefix .. delimiter .. short_suffix
   end
+
   text = text:gsub("^%s*", "")
   return string.len(text) > 40 and shorten(text) or text
 end
@@ -68,7 +73,8 @@ function source.complete(self, params, callback)
 
   local completion_text = (inlay_instance.line_before_cursor) .. inlay_instance.completion_text
   local preview_text    = completion_text
-  local label           = label_text(vim.split(completion_text, "\n", { plain = true })[1])
+  local split           = vim.split(completion_text, "\n", { plain = true })
+  local label           = label_text(split[1], #split)
   -- local label           = u.trim_start(vim.split(completion_text, "\n", { plain = true })[1])
 
   -- print("Completion label:", label)

--- a/lua/supermaven-nvim/completion_preview.lua
+++ b/lua/supermaven-nvim/completion_preview.lua
@@ -127,6 +127,10 @@ function CompletionPreview:should_completion_be_active(completion_text, line_bef
   return false
 end
 
+function CompletionPreview:get_inlay_instance()
+  return self.inlay_instance
+end
+
 function CompletionPreview.on_accept_suggestion(is_partial)
   local accept_completion = CompletionPreview:accept_completion_text(is_partial)
   if accept_completion ~= nil and accept_completion.is_active then
@@ -165,8 +169,10 @@ function CompletionPreview.on_dispose_inlay()
   CompletionPreview:dispose_inlay()
 end
 
-function CompletionPreview:get_inlay_instance()
-  return self.inlay_instance
+function CompletionPreview.has_suggestion()
+  local inlay_instance = CompletionPreview:get_inlay_instance()
+  return inlay_instance ~= nil and inlay_instance.is_active and inlay_instance.completion_text ~= nil and
+      inlay_instance.completion_text ~= ""
 end
 
 return CompletionPreview

--- a/lua/supermaven-nvim/config.lua
+++ b/lua/supermaven-nvim/config.lua
@@ -5,6 +5,7 @@ local default_config = {
     accept_word = "<C-j>",
   },
   ignore_filetypes = {},
+  disable_inline_completion = false
 }
 
 M = {}

--- a/lua/supermaven-nvim/config.lua
+++ b/lua/supermaven-nvim/config.lua
@@ -5,7 +5,8 @@ local default_config = {
     accept_word = "<C-j>",
   },
   ignore_filetypes = {},
-  disable_inline_completion = false
+  disable_inline_completion = false,
+  disable_keymaps = false
 }
 
 M = {}
@@ -16,3 +17,4 @@ M.setup_config = function(args)
 end
 
 return M
+

--- a/lua/supermaven-nvim/init.lua
+++ b/lua/supermaven-nvim/init.lua
@@ -6,13 +6,12 @@ local config = require("supermaven-nvim.config")
 
 M = {}
 
-
 M.setup = function(args)
   local config_settings = config.setup_config(args)
 
   if config_settings.disable_inline_completion then
     completion_preview.disable_inline_completion = true
-  else
+  elseif not config_settings.disable_keymaps then
     if config_settings.keymaps.accept_suggestion ~= nil then
       local accept_suggestion_key = config_settings.keymaps.accept_suggestion
       vim.keymap.set('i', accept_suggestion_key, completion_preview.on_accept_suggestion,

--- a/lua/supermaven-nvim/init.lua
+++ b/lua/supermaven-nvim/init.lua
@@ -6,35 +6,56 @@ local config = require("supermaven-nvim.config")
 
 M = {}
 
+
 M.setup = function(args)
   local config_settings = config.setup_config(args)
-  if config_settings.keymaps.accept_suggestion ~= nil then
-    local accept_suggestion_key = config_settings.keymaps.accept_suggestion
-    vim.keymap.set('i', accept_suggestion_key, completion_preview.on_accept_suggestion, { noremap = true, silent = true })
+
+  if config_settings.disable_inline_completion then
+    completion_preview.disable_inline_completion = true
+  else
+    if config_settings.keymaps.accept_suggestion ~= nil then
+      local accept_suggestion_key = config_settings.keymaps.accept_suggestion
+      vim.keymap.set('i', accept_suggestion_key, completion_preview.on_accept_suggestion,
+        { noremap = true, silent = true })
+    end
+
+    if config_settings.keymaps.accept_word ~= nil then
+      local accept_word_key = config_settings.keymaps.accept_word
+      vim.keymap.set('i', accept_word_key, completion_preview.on_accept_suggestion_word,
+        { noremap = true, silent = true })
+    end
+
+    if config_settings.keymaps.clear_suggestion ~= nil then
+      local clear_suggestion_key = config_settings.keymaps.clear_suggestion
+      vim.keymap.set('i', clear_suggestion_key, completion_preview.on_dispose_inlay, { noremap = true, silent = true })
+    end
   end
 
-  if config_settings.keymaps.accept_word ~= nil then
-    local accept_word_key = config_settings.keymaps.accept_word
-    vim.keymap.set('i', accept_word_key, completion_preview.on_accept_suggestion_word, { noremap = true, silent = true })
-  end
-
-  if config_settings.keymaps.clear_suggestion ~= nil then
-    local clear_suggestion_key = config_settings.keymaps.clear_suggestion
-    vim.keymap.set('i', clear_suggestion_key, completion_preview.on_dispose_inlay, { noremap = true, silent = true })
-  end
   binary:start_binary(config_settings.ignore_filetypes or {})
 
   if config_settings.color and config_settings.color.suggestion_color and config_settings.color.cterm then
-    vim.api.nvim_create_autocmd({"VimEnter", "ColorScheme"}, {
+    vim.api.nvim_create_autocmd({ "VimEnter", "ColorScheme" }, {
       pattern = "*",
       callback = function(event)
-        vim.api.nvim_set_hl(0, "SupermavenSuggestion", { 
+        vim.api.nvim_set_hl(0, "SupermavenSuggestion", {
           fg = config_settings.color.suggestion_color,
           ctermfg = config_settings.color.cterm,
         })
         completion_preview.suggestion_group = "SupermavenSuggestion"
       end
     })
+  end
+
+  local cmp_ok, cmp = pcall(require, "cmp")
+  if cmp_ok then
+    local cmp_source = require("supermaven-nvim.cmp")
+    cmp.register_source("supermaven", cmp_source.new())
+  else
+    if config_settings.disable_inline_completion then
+      vim.notify(
+        "nvim-cmp is not available, but inline completion is disabled. SuperMaven nvim-cmp source will not be registered.",
+        vim.log.levels.WARN)
+    end
   end
 end
 


### PR DESCRIPTION
# Description

This pull request adds new nvim-cmp compatibility by registering itself as a source when nvim-cmp is found. This makes the plugin much more usable to me and removes the conflict between inline suggestions and cmp's suggestions. I have seen similar requests passing by a couple of times on Discord as well. Additionally, a new configuration option disable_inline_completion has been introduced to allow users to disable the built-in inline completions when relying on the nvim-cmp ones. I have also updated the README accordingly.

It seemed much nicer and more integrated to have this feature in the main repo. However, with a joint effort, it can be made into a separate plugin as well.

While at it, I also added a helper function ```.has_suggestion()``` to help with alternative implementations. (#10) (#15)

Please let me know if there is anything else I need to address before accepting this pull request.


https://github.com/supermaven-inc/supermaven-nvim/assets/87830/fce213d3-0a5c-4dce-b5ae-d9db326078aa


## Type of change

- New feature (non-breaking change which adds functionality)
- This change requires a documentation update

## How Has This Been Tested?

I have tested it thoroughly on Lua and TypeScript projects, and it works as expected, providing both single and multi-line suggestions.

**Configuration**:

- Neovim version (`nvim --version`): 0.9.5
- Operating system and version: macOS 14.4.1 (Sonoma)

## Checklist

- [ x ] My code follows the style guidelines of this project (stylua)
- [ x ] I have performed a self-review of my own code
- [ x ] I have commented my code, particularly in hard-to-understand areas
- [ x ] I have made corresponding changes to the documentation