### PR TITLE
feature update: use cmp built in types and cursor; add pro tip to readme

### DIFF
--- a/lua/supermaven-nvim/cmp.lua
+++ b/lua/supermaven-nvim/cmp.lua
@@ -3,11 +3,7 @@ local CompletionPreview = require("supermaven-nvim.completion_preview")
 
 local source = { executions = {}, }
 
-local label_text = function(text, lines)
-  if lines > 1 then
-    text = text .. " ~"
-  end
-
+local label_text = function(text)
   local shorten = function(str)
     local short_prefix = string.sub(str, 0, 20)
     local short_suffix = string.sub(str, string.len(str) - 15, string.len(str))
@@ -56,35 +52,38 @@ function source.complete(self, params, callback)
     return
   end
 
-  -- local context         = params.context
-  local cursor          = vim.api.nvim_win_get_cursor(0)
+  local context          = params.context
+  local cursor           = context.cursor
 
-  local range           = {
+  local completion_text  = (inlay_instance.line_before_cursor) .. inlay_instance.completion_text
+  local preview_text     = completion_text
+  local split            = vim.split(completion_text, "\n", { plain = true })
+  local label            = label_text(split[1])
+
+  local insertTextFormat = 1 -- cmp.lsp.InsertTextFormat.PlainText
+
+  if #split > 1 then
+    insertTextFormat = 2 -- cmp.lsp.InsertTextFormat.Snippet
+  end
+
+  local range = {
     start = {
-      line = cursor[1] - 1,
-      -- character = math.max(cursor[2] - inlay_instance.prior_delete, 0),
-      character = vim.fn.col("0")
+      line = cursor.line,
+      character = math.max(cursor.col - inlay_instance.prior_delete - #inlay_instance.line_before_cursor - 1, 0)
     },
     ["end"] = {
-      line = cursor[1] - 1,
+      line = cursor.line,
       character = vim.fn.col("$")
     }
   }
 
-  local completion_text = (inlay_instance.line_before_cursor) .. inlay_instance.completion_text
-  local preview_text    = completion_text
-  local split           = vim.split(completion_text, "\n", { plain = true })
-  local label           = label_text(split[1], #split)
-  -- local label           = u.trim_start(vim.split(completion_text, "\n", { plain = true })[1])
-
-  -- print("Completion label:", label)
-
-  local items           = {
+  local items = {
     {
       label = label,
       kind = 1,
       score = 100,
       filterText = nil,
+      insertTextFormat = insertTextFormat,
       cmp = {
         kind_hl_group = "CmpItemKindSupermaven",
         kind_text = 'Supermaven',


### PR DESCRIPTION
# Description

I previously made a PR (accepted) which introduced cmp source integration and a couple of convenience methods. #28 

This pull request contains a minor update to make better use of built in cmp types and multi line markers, cursor, etc. I had added my own marker previously, so it doesn't change much. But I feel it is cleaner this way.

I also tried to simulate the built in continuous inline completions with cmp and came up with a solution which has been working nicely for me for the last couple of days now, so I thought I could share this as a "pro tip" in the README, although this may perhaps be better suited for a wiki in the future.
 
The new README suggestion is demonstrated in this video:

https://github.com/supermaven-inc/supermaven-nvim/assets/87830/9871857a-56d3-44f9-abfc-b727f01d3565


Please let me know if there is anything else I need to address before accepting this pull request.

## Type of change

- New feature (non-breaking change which adds functionality)
- This change requires a documentation update

## How Has This Been Tested?

I have tested it thoroughly on Lua and TypeScript projects, and it works as expected, providing both single and multi-line suggestions.

**Configuration**:

- Neovim version (`nvim --version`): 0.9.5
- Operating system and version: macOS 14.4.1 (Sonoma)

## Checklist

- [ x ] My code follows the style guidelines of this project (stylua)
- [ x ] I have performed a self-review of my own code
- [ x ] I have commented my code, particularly in hard-to-understand areas
- [ x ] I have made corresponding changes to the documentation


