### PR TITLE
FIX: Windows OS web fetching

### DIFF
--- a/lua/supermaven-nvim/binary/binary_fetcher.lua
+++ b/lua/supermaven-nvim/binary/binary_fetcher.lua
@@ -32,7 +32,18 @@ function BinaryFetcher:discover_binary_url()
   local url = "https://supermaven.com/api/download-path?platform=" .. platform .. "&arch=" .. arch .. "&editor=neovim"
   local response = ""
   if platform == "windows" then
-    response = vim.fn.system { 'powershell', '-Command', 'Invoke-WebRequest', '-Uri', "'" .. url .. "'", '-UseBasicParsing', '|', 'Select-Object', '-ExpandProperty', 'Content' }
+    response = vim.fn.system {
+      'powershell',
+      '-Command',
+      'Invoke-WebRequest',
+      '-Uri',
+      "'" .. url .. "'",
+      '-UseBasicParsing',
+      '|',
+      'Select-Object',
+      '-ExpandProperty',
+      'Content'
+    }
     response = string.gsub(response, "[\r\n]+", "")
   else
     response = vim.fn.system("curl -s " .. "'" .. url .. "'")
@@ -69,7 +80,15 @@ function BinaryFetcher:fetch_binary()
   local platform = self:platform()
   local response = ""
   if platform == "windows" then
-    response = vim.fn.system { 'powershell', '-Command', 'Invoke-WebRequest', '-Uri', "'" .. url .. "'", '-OutFile', "'" .. local_binary_path .. "'" }
+    response = vim.fn.system {
+      'powershell',
+      '-Command',
+      'Invoke-WebRequest',
+      '-Uri',
+      "'" .. url .. "'",
+      '-OutFile',
+      "'" .. local_binary_path .. "'"
+    }
   else
     response = vim.fn.system("curl -o " .. local_binary_path .. " " .. "'" .. url .. "'")
   end

--- a/lua/supermaven-nvim/binary/binary_fetcher.lua
+++ b/lua/supermaven-nvim/binary/binary_fetcher.lua
@@ -32,7 +32,7 @@ function BinaryFetcher:discover_binary_url()
   local url = "https://supermaven.com/api/download-path?platform=" .. platform .. "&arch=" .. arch .. "&editor=neovim"
   local response = ""
   if platform == "windows" then
-    response = vim.fn.system('powershell -Command "Invoke-WebRequest -Uri ' .. "'" .. url .. "'" .. ' -UseBasicParsing | Select-Object -ExpandProperty Content"')
+    response = vim.fn.system { 'powershell', '-Command', 'Invoke-WebRequest', '-Uri', "'" .. url .. "'", '-UseBasicParsing', '|', 'Select-Object', '-ExpandProperty', 'Content' }
     response = string.gsub(response, "[\r\n]+", "")
   else
     response = vim.fn.system("curl -s " .. "'" .. url .. "'")
@@ -69,7 +69,7 @@ function BinaryFetcher:fetch_binary()
   local platform = self:platform()
   local response = ""
   if platform == "windows" then
-    response = vim.fn.system('powershell -Command "Invoke-WebRequest -Uri ' .. "'" .. url .. "'" .. ' -OutFile ' .. "'" .. local_binary_path .. "'" .. '"')
+    response = vim.fn.system { 'powershell', '-Command', 'Invoke-WebRequest', '-Uri', "'" .. url .. "'", '-OutFile', "'" .. local_binary_path .. "'" }
   else
     response = vim.fn.system("curl -o " .. local_binary_path .. " " .. "'" .. url .. "'")
   end


### PR DESCRIPTION
It was failing to download anything for me on Windows version of nvim.
After spreading `vim.fn.system` it works - must be something to do with how spaces/quotes are handled in Windows OS.