### PR TITLE
Pass array instead of raw string

### DIFF
--- a/lua/supermaven-nvim/binary/binary_fetcher.lua
+++ b/lua/supermaven-nvim/binary/binary_fetcher.lua
@@ -46,7 +46,7 @@ function BinaryFetcher:discover_binary_url()
     }
     response = string.gsub(response, "[\r\n]+", "")
   else
-    response = vim.fn.system("curl -s " .. "'" .. url .. "'")
+    response = vim.fn.system({"curl", "-s", url})
   end
 
   local json = vim.fn.json_decode(response)

--- a/lua/supermaven-nvim/binary/binary_fetcher.lua
+++ b/lua/supermaven-nvim/binary/binary_fetcher.lua
@@ -90,7 +90,7 @@ function BinaryFetcher:fetch_binary()
       "'" .. local_binary_path .. "'"
     }
   else
-    response = vim.fn.system("curl -o " .. local_binary_path .. " " .. "'" .. url .. "'")
+    response = vim.fn.system({"curl", "-o", local_binary_path, url})
   end
   if vim.v.shell_error == 0 then
     print("Downloaded binary sm-agent to " .. local_binary_path)


### PR DESCRIPTION
Solves https://github.com/supermaven-inc/supermaven-nvim/issues/19 by using the list-style invocation of `vim.fn.system`, which does not prefix the result with gabrage bytes for some reason.

For details see [this comment](https://github.com/supermaven-inc/supermaven-nvim/issues/19#issuecomment-2139229521)