### PR TITLE
fix(#12): ensure ignoring filetypes properly

### DIFF
--- a/lua/supermaven-nvim/binary/binary_handler.lua
+++ b/lua/supermaven-nvim/binary/binary_handler.lua
@@ -73,11 +73,6 @@ end
 
 function BinaryLifecycle:on_update(buffer, file_name, event_type)
   if config.ignore_filetypes[vim.bo.ft] then
-    if self.handle ~= nil then
-      self.handle:close()
-      self.handle = nil
-    end
-    self.wants_polling = false
     return
   end
   local buffer_text = u.get_text(buffer)
@@ -291,11 +286,6 @@ end
 
 function BinaryLifecycle:poll_once()
   if config.ignore_filetypes[vim.bo.ft] then
-    if self.handle ~= nil then
-      self.handle:close()
-      self.handle = nil
-    end
-    self.wants_polling = false
     return
   end
   local now = vim.loop.now()

--- a/lua/supermaven-nvim/binary/binary_handler.lua
+++ b/lua/supermaven-nvim/binary/binary_handler.lua
@@ -72,7 +72,7 @@ function BinaryLifecycle:greeting_message()
 end
 
 function BinaryLifecycle:on_update(buffer, file_name, event_type)
-  if vim.tbl_contains(self.ignore_filetypes, vim.bo.ft) or self.ignore_filetypes[vim.bo.ft] then
+  if vim.tbl_contains(config.ignore_filetypes, vim.bo.ft) or config.ignore_filetypes[vim.bo.ft] then
     if self.handle ~= nil then
       self.handle:close()
       self.handle = nil
@@ -290,7 +290,7 @@ function BinaryLifecycle:provide_inline_completion_items(buffer, cursor, context
 end
 
 function BinaryLifecycle:poll_once()
-  if vim.tbl_contains(self.ignore_filetypes, vim.bo.ft) or self.ignore_filetypes[vim.bo.ft] then
+  if vim.tbl_contains(config.ignore_filetypes, vim.bo.ft) or config.ignore_filetypes[vim.bo.ft] then
     if self.handle ~= nil then
       self.handle:close()
       self.handle = nil
@@ -298,6 +298,7 @@ function BinaryLifecycle:poll_once()
     self.wants_polling = false
     return
   end
+  local now = vim.loop.now()
   if now - self.last_provide_time > 5 * 1000 then
     self.wants_polling = false
     return

--- a/lua/supermaven-nvim/binary/binary_handler.lua
+++ b/lua/supermaven-nvim/binary/binary_handler.lua
@@ -72,7 +72,7 @@ function BinaryLifecycle:greeting_message()
 end
 
 function BinaryLifecycle:on_update(buffer, file_name, event_type)
-  if vim.tbl_contains(config.ignore_filetypes, vim.bo.ft) or config.ignore_filetypes[vim.bo.ft] then
+  if config.ignore_filetypes[vim.bo.ft] then
     if self.handle ~= nil then
       self.handle:close()
       self.handle = nil
@@ -290,7 +290,7 @@ function BinaryLifecycle:provide_inline_completion_items(buffer, cursor, context
 end
 
 function BinaryLifecycle:poll_once()
-  if vim.tbl_contains(config.ignore_filetypes, vim.bo.ft) or config.ignore_filetypes[vim.bo.ft] then
+  if config.ignore_filetypes[vim.bo.ft] then
     if self.handle ~= nil then
       self.handle:close()
       self.handle = nil

--- a/lua/supermaven-nvim/binary/binary_handler.lua
+++ b/lua/supermaven-nvim/binary/binary_handler.lua
@@ -61,15 +61,13 @@ function BinaryLifecycle:greeting_message()
 end
 
 function BinaryLifecycle:on_update(buffer, file_name, event_type)
-  for _, filetype in ipairs(self.ignore_filetypes) do
-    if vim.bo.ft == filetype then
-      if self.handle ~= nil then
-        self.handle:close()
-        self.handle = nil
-      end
-      self.wants_polling = false
-      return
+  if vim.tbl_contains(self.ignore_filetypes, vim.bo.ft) or self.ignore_filetypes[vim.bo.ft] then
+    if self.handle ~= nil then
+      self.handle:close()
+      self.handle = nil
     end
+    self.wants_polling = false
+    return
   end
   local buffer_text = u.get_text(buffer)
   local updates = {
@@ -291,15 +289,13 @@ function BinaryLifecycle:provide_inline_completion_items(buffer, cursor, context
 end
 
 function BinaryLifecycle:poll_once()
-  for _, filetype in ipairs(self.ignore_filetypes) do
-    if vim.bo.ft == filetype then
-      if self.handle ~= nil then
-        self.handle:close()
-        self.handle = nil
-      end
-      self.wants_polling = false
-      return
+  if vim.tbl_contains(self.ignore_filetypes, vim.bo.ft) or self.ignore_filetypes[vim.bo.ft] then
+    if self.handle ~= nil then
+      self.handle:close()
+      self.handle = nil
     end
+    self.wants_polling = false
+    return
   end
   local now = vim.loop.now()
   if now - self.last_provide_time > 5 * 1000 then


### PR DESCRIPTION
When testing out the issue in #12 I found that the files in `ignore_filetypes` were not being ignored properly causing it to still process them. In my case I ignored `.lua` and `.md` filetypes and still was giving me suggestions.

After this fix, it no longer gives me suggestions and it prevents supermaven from starting in ignored files but works fine when changing to a non-ingored filetype.

For the video I used this configuration:

```lua
require("supermaven-nvim").setup({
  ignore_filetypes = {
    "lua",
  },
})
```

https://github.com/supermaven-inc/supermaven-nvim/assets/71392160/a3ff66c4-a372-4995-8112-a340b8b69352

> [!NOTE]
> In the video I forgot to show that going from the non-ignored `.md` to an ingored `.lua` stops showing suggestions or 'polling' or updating until you change to a non-ignored filetype.

Fixes #12