### PR TITLE
feat(xdg spec): use $XDG_DATA_HOME by default

### DIFF
--- a/lua/supermaven-nvim/binary/binary_fetcher.lua
+++ b/lua/supermaven-nvim/binary/binary_fetcher.lua
@@ -112,7 +112,14 @@ end
 
 function BinaryFetcher:local_binary_parent_path()
   local home_dir = self.homedir
-  return home_dir .. "/.supermaven/binary/v15/" .. self:platform() .. "-" .. self:get_arch()
+  local data_dir = os.getenv("XDG_DATA_HOME")
+  local dir
+  if data_dir then
+    dir = data_dir .. "/supermaven"
+  else
+    dir = home_dir .. "/.supermaven"
+  end
+  return dir .. "/binary/v15/" .. self:platform() .. "-" .. self:get_arch()
 end
 
 


### PR DESCRIPTION
Seems the sm-agent binary still create the ~/.supermaven/config.json, sm-agent will need to be updated upstream

close #37 