### PR TITLE
feat(#36): add toggle to enable/disable suggestions 

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@ By default, supermaven-nvim will use the `<Tab>` and `<C-]>` keymaps to accept a
 
 The `ignore_filetypes` table is used to ignore filetypes when using supermaven-nvim. If a filetype is present as a key, and its value is `true`, supermaven-nvim will not display suggestions for that filetype.
 
+It is possible to completely disable the suggestions temporarily, or toggle it on or off. By default the keymap is set to `<C-\\>`. The plugin can also start with suggestions disabled by default using the `suggestions_start_disabled` option.
+
 `suggestion_color` and `cterm` options can be used to set the color of the suggestion text.
 
 ```lua
@@ -44,6 +46,7 @@ require("supermaven-nvim").setup({
     accept_suggestion = "<Tab>",
     clear_suggestion = "<C-]>",
     accept_word = "<C-j>",
+    toggle_suggestions = "<C-\\>",
   },
   ignore_filetypes = { cpp = true },
   color = {
@@ -52,6 +55,7 @@ require("supermaven-nvim").setup({
   },
   disable_inline_completion = false, -- disables inline completion for use with cmp
   disable_keymaps = false -- disables built in keymaps for more manual control
+  suggestions_start_disabled = false -- disables all suggestions by default, must be used with toggle_suggestions
 })
 ```
 

--- a/lua/supermaven-nvim/completion_preview.lua
+++ b/lua/supermaven-nvim/completion_preview.lua
@@ -5,6 +5,7 @@ local CompletionPreview = {
   ns_id = vim.api.nvim_create_namespace('supermaven'),
   suggestion_group = "Comment",
   disable_inline_completion = false,
+  disable_suggestions = false,
 }
 
 CompletionPreview.__index = CompletionPreview
@@ -13,6 +14,10 @@ function CompletionPreview:render_with_inlay(buffer, prior_delete, completion_te
   self:dispose_inlay()
 
   if not buffer then
+    return
+  end
+
+  if self.disable_suggestions then
     return
   end
 
@@ -173,6 +178,14 @@ function CompletionPreview.has_suggestion()
   local inlay_instance = CompletionPreview:get_inlay_instance()
   return inlay_instance ~= nil and inlay_instance.is_active and inlay_instance.completion_text ~= nil and
       inlay_instance.completion_text ~= ""
+end
+
+function CompletionPreview:on_toggle_suggestions()
+  CompletionPreview:toggle_suggestions()
+end
+
+function CompletionPreview:toggle_suggestions()
+  self.disable_suggestions = not self.disable_suggestions
 end
 
 return CompletionPreview

--- a/lua/supermaven-nvim/config.lua
+++ b/lua/supermaven-nvim/config.lua
@@ -3,8 +3,10 @@ local default_config = {
     accept_suggestion = "<Tab>",
     clear_suggestion = "<C-]>",
     accept_word = "<C-j>",
+    toggle_suggestions = "<C-\\>",
   },
   ignore_filetypes = {},
+  suggestions_start_disabled = false,
   disable_inline_completion = false,
   disable_keymaps = false
 }

--- a/lua/supermaven-nvim/init.lua
+++ b/lua/supermaven-nvim/init.lua
@@ -9,6 +9,10 @@ M = {}
 M.setup = function(args)
   local config_settings = config.setup_config(args)
 
+  if config_settings.suggestions_start_disabled then
+    completion_preview.disable_suggestions = true
+  end
+
   if config_settings.disable_inline_completion then
     completion_preview.disable_inline_completion = true
   elseif not config_settings.disable_keymaps then
@@ -27,6 +31,11 @@ M.setup = function(args)
     if config_settings.keymaps.clear_suggestion ~= nil then
       local clear_suggestion_key = config_settings.keymaps.clear_suggestion
       vim.keymap.set('i', clear_suggestion_key, completion_preview.on_dispose_inlay, { noremap = true, silent = true })
+    end
+
+    if config_settings.keymaps.toggle_suggestions ~= nil then
+      local toggle_suggestions_key = config_settings.keymaps.toggle_suggestions
+      vim.keymap.set('i', toggle_suggestions_key, completion_preview.on_toggle_suggestions, { noremap = true, silent = true })
     end
   end
 


### PR DESCRIPTION
# Description

This PR adds the ability to toggle suggestions on and off through a keymap, and the option to always start neovim with suggestions disabled.

Fixes #36 

## Type of change

Please delete options that are not relevant.

- New feature (non-breaking change which adds functionality)
- This change requires a documentation update

## How Has This Been Tested?

I have tested it on my machine and it works as expected, behaving the same way as the VS Code extension does. The only difference being that on this plugin the toggle is local to each instance of neovim, and on VS Code the toggle is done globally across all windows.

**Configuration**:

- Neovim version (`nvim --version`): 0.9.5
- Operating system and version: openSUSE Tumbleweed

## Checklist

- [X] My code follows the style guidelines of this project (stylua)
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation