### PR TITLE
Feat: Make supermaven-nvim stoppable and minor refactor to follow best practices

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,3 +133,33 @@ end
 Upon starting supermaven-nvim, you will be prompted to either use the Free Tier with the command `:SupermavenUseFree` or to activate a Supermaven Pro subscription by following a link, which will connect your Supermaven account.
 
 If Supermaven is set up, you can use `:SupermavenLogout` to switch versions.
+
+### Commands
+
+Supermaven-nvim provides the following commands:
+
+```
+:SupermavenStart   start supermaven-nvim
+:SupermavenStop    stop supermaven-nvim
+:SupermavenRestart restart supermaven-nvim
+:SupermavenStatus  show status of supermaven-nvim
+:SupermavenUseFree switch to the free version
+:SupermavenUsePro  switch to the pro version
+:SupermavenLogout  log out of supermaven
+```
+
+### Lua API
+
+The `supermaven-nvim.api` module provides the following functions for interacting with supermaven-nvim from Lua:
+
+```lua
+local api = require("supermaven-nvim.api")
+
+api.start() -- starts supermaven-nvim
+api.stop() -- stops supermaven-nvim
+api.restart() -- restarts supermaven-nvim if it is running, otherwise starts it
+api.is_running() -- returns true if supermaven-nvim is running
+api.use_free_version() -- switch to the free version
+api.use_pro() -- switch to the pro version
+api.logout() -- log out of supermaven
+```

--- a/README.md
+++ b/README.md
@@ -142,6 +142,7 @@ Supermaven-nvim provides the following commands:
 :SupermavenStart   start supermaven-nvim
 :SupermavenStop    stop supermaven-nvim
 :SupermavenRestart restart supermaven-nvim
+:SupermavenToggle  toggle supermaven-nvim
 :SupermavenStatus  show status of supermaven-nvim
 :SupermavenUseFree switch to the free version
 :SupermavenUsePro  switch to the pro version
@@ -158,6 +159,7 @@ local api = require("supermaven-nvim.api")
 api.start() -- starts supermaven-nvim
 api.stop() -- stops supermaven-nvim
 api.restart() -- restarts supermaven-nvim if it is running, otherwise starts it
+api.toggle() -- toggles supermaven-nvim
 api.is_running() -- returns true if supermaven-nvim is running
 api.use_free_version() -- switch to the free version
 api.use_pro() -- switch to the pro version

--- a/lua/supermaven-nvim/api.lua
+++ b/lua/supermaven-nvim/api.lua
@@ -33,12 +33,12 @@ M.use_free_version = function()
   binary:use_free_version()
 end
 
-M.logout = function()
-  binary:logout()
-end
-
 M.use_pro = function()
   binary:use_pro()
+end
+
+M.logout = function()
+  binary:logout()
 end
 
 return M

--- a/lua/supermaven-nvim/api.lua
+++ b/lua/supermaven-nvim/api.lua
@@ -25,7 +25,9 @@ M.stop = function()
 end
 
 M.restart = function()
-  M.stop()
+  if M.is_running() then
+    M.stop()
+  end
   M.start()
 end
 

--- a/lua/supermaven-nvim/api.lua
+++ b/lua/supermaven-nvim/api.lua
@@ -1,0 +1,26 @@
+local binary = require("supermaven-nvim.binary.binary_handler")
+local listener = require("supermaven-nvim.document_listener")
+
+local M = {}
+
+M.start = function()
+  if M.is_running() then
+    vim.notify("Supermaven is already running.", vim.log.levels.WARN)
+  end
+  binary:start_binary()
+  listener.setup()
+end
+
+M.use_free_version = function()
+  binary:use_free_version()
+end
+
+M.logout = function()
+  binary:logout()
+end
+
+M.use_pro = function()
+  binary:use_pro()
+end
+
+return M

--- a/lua/supermaven-nvim/api.lua
+++ b/lua/supermaven-nvim/api.lua
@@ -31,6 +31,14 @@ M.restart = function()
   M.start()
 end
 
+M.toggle = function()
+  if M.is_running() then
+    M.stop()
+  else
+    M.start()
+  end
+end
+
 M.use_free_version = function()
   binary:use_free_version()
 end

--- a/lua/supermaven-nvim/api.lua
+++ b/lua/supermaven-nvim/api.lua
@@ -3,12 +3,30 @@ local listener = require("supermaven-nvim.document_listener")
 
 local M = {}
 
+M.is_running = function()
+  return binary:is_running()
+end
+
 M.start = function()
   if M.is_running() then
     vim.notify("Supermaven is already running.", vim.log.levels.WARN)
   end
   binary:start_binary()
   listener.setup()
+end
+
+M.stop = function()
+  if not M.is_running() then
+    vim.notify("Supermaven is not running.", vim.log.levels.WARN)
+    return
+  end
+  listener.teardown()
+  binary:stop_binary()
+end
+
+M.restart = function()
+  M.stop()
+  M.start()
 end
 
 M.use_free_version = function()

--- a/lua/supermaven-nvim/binary/binary_fetcher.lua
+++ b/lua/supermaven-nvim/binary/binary_fetcher.lua
@@ -2,7 +2,7 @@ local BinaryFetcher = {
   binary_path = nil,
   binary_url = nil,
   os_uname = vim.loop.os_uname(),
-  homedir = vim.loop.os_homedir()
+  homedir = vim.loop.os_homedir(),
 }
 
 function BinaryFetcher:platform()
@@ -23,7 +23,7 @@ function BinaryFetcher:get_arch()
   elseif self.os_uname.machine == "x86_64" then
     return "x86_64"
   end
-    return ""
+  return ""
 end
 
 function BinaryFetcher:discover_binary_url()
@@ -32,21 +32,21 @@ function BinaryFetcher:discover_binary_url()
   local url = "https://supermaven.com/api/download-path?platform=" .. platform .. "&arch=" .. arch .. "&editor=neovim"
   local response = ""
   if platform == "windows" then
-    response = vim.fn.system {
-      'powershell',
-      '-Command',
-      'Invoke-WebRequest',
-      '-Uri',
+    response = vim.fn.system({
+      "powershell",
+      "-Command",
+      "Invoke-WebRequest",
+      "-Uri",
       "'" .. url .. "'",
-      '-UseBasicParsing',
-      '|',
-      'Select-Object',
-      '-ExpandProperty',
-      'Content'
-    }
+      "-UseBasicParsing",
+      "|",
+      "Select-Object",
+      "-ExpandProperty",
+      "Content",
+    })
     response = string.gsub(response, "[\r\n]+", "")
   else
-    response = vim.fn.system({"curl", "-s", url})
+    response = vim.fn.system({ "curl", "-s", url })
   end
 
   local json = vim.fn.json_decode(response)
@@ -80,17 +80,17 @@ function BinaryFetcher:fetch_binary()
   local platform = self:platform()
   local response = ""
   if platform == "windows" then
-    response = vim.fn.system {
-      'powershell',
-      '-Command',
-      'Invoke-WebRequest',
-      '-Uri',
+    response = vim.fn.system({
+      "powershell",
+      "-Command",
+      "Invoke-WebRequest",
+      "-Uri",
       "'" .. url .. "'",
-      '-OutFile',
-      "'" .. local_binary_path .. "'"
-    }
+      "-OutFile",
+      "'" .. local_binary_path .. "'",
+    })
   else
-    response = vim.fn.system({"curl", "-o", local_binary_path, url})
+    response = vim.fn.system({ "curl", "-o", local_binary_path, url })
   end
   if vim.v.shell_error == 0 then
     print("Downloaded binary sm-agent to " .. local_binary_path)
@@ -114,6 +114,5 @@ function BinaryFetcher:local_binary_parent_path()
   local home_dir = self.homedir
   return home_dir .. "/.supermaven/binary/v15/" .. self:platform() .. "-" .. self:get_arch()
 end
-
 
 return BinaryFetcher

--- a/lua/supermaven-nvim/binary/binary_handler.lua
+++ b/lua/supermaven-nvim/binary/binary_handler.lua
@@ -2,6 +2,7 @@ local loop = vim.loop
 local api = vim.api
 local u = require("supermaven-nvim.util")
 local textual = require("supermaven-nvim.textual")
+local config = require("supermaven-nvim.config")
 local preview = require("supermaven-nvim.completion_preview")
 local binary_fetcher = require("supermaven-nvim.binary.binary_fetcher")
 
@@ -15,7 +16,6 @@ local BinaryLifecycle = {
   buffer = nil,
   cursor = nil,
   max_state_id_retention = 50,
-  ignore_filetypes = {},
   service_message_displayed = false,
 }
 
@@ -26,8 +26,7 @@ timer:start(0, 25, vim.schedule_wrap(function()
   end
 end))
 
-function BinaryLifecycle:start_binary(ignore_filetypes)
-  self.ignore_filetypes = ignore_filetypes
+function BinaryLifecycle:start_binary()
   self.stdin = loop.new_pipe(false)
   self.stdout = loop.new_pipe(false)
   self.stderr = loop.new_pipe(false)
@@ -110,7 +109,7 @@ function BinaryLifecycle:check_process()
     self.handle:close()
   end
 
-  self:start_binary(self.ignore_filetypes)
+  self:start_binary()
 end
 
 function BinaryLifecycle:same_context(context)
@@ -286,7 +285,7 @@ function BinaryLifecycle:poll_once()
     self.wants_polling = false
     return
   end
-  if self.ignore_filetypes[vim.bo.filetype] then
+  if config.ignore_filetypes[vim.bo.filetype] then
     return
   end
   self.wants_polling = true

--- a/lua/supermaven-nvim/binary/binary_handler.lua
+++ b/lua/supermaven-nvim/binary/binary_handler.lua
@@ -54,6 +54,10 @@ function BinaryLifecycle:start_binary()
   self:greeting_message()
 end
 
+function BinaryLifecycle:is_running()
+  return self.handle ~= nil and self.handle:is_active()
+end
+
 function BinaryLifecycle:greeting_message()
   local message = vim.json.encode({ kind = "greeting", allowGitignore = false }) .. "\n"
   loop.write(self.stdin, message) -- fails silently
@@ -424,17 +428,6 @@ function BinaryLifecycle:show_activation_message()
   end
 end
 
-vim.api.nvim_create_user_command("SupermavenUseFree", function()
-  BinaryLifecycle:use_free_version()
-end, {})
-
-vim.api.nvim_create_user_command("SupermavenLogout", function()
-  BinaryLifecycle:logout()
-end, {})
-
-vim.api.nvim_create_user_command("SupermavenUsePro", function()
-  BinaryLifecycle:use_pro()
-end, {})
 
 function BinaryLifecycle:use_free_version()
   local message = vim.json.encode({ kind = "use_free_version" }) .. "\n"

--- a/lua/supermaven-nvim/cmp.lua
+++ b/lua/supermaven-nvim/cmp.lua
@@ -1,6 +1,6 @@
 local CompletionPreview = require("supermaven-nvim.completion_preview")
 
-local source = { executions = {}, }
+local source = { executions = {} }
 
 local label_text = function(text, lines)
   if lines > 1 then
@@ -19,11 +19,11 @@ local label_text = function(text, lines)
 end
 
 function source.get_trigger_characters()
-  return { '*' }
+  return { "*" }
 end
 
 function source.get_keyword_pattern()
-  return '.'
+  return "."
 end
 
 function source.is_available()
@@ -56,29 +56,29 @@ function source.complete(self, params, callback)
   end
 
   -- local context         = params.context
-  local cursor          = vim.api.nvim_win_get_cursor(0)
+  local cursor = vim.api.nvim_win_get_cursor(0)
 
-  local range           = {
+  local range = {
     start = {
       line = cursor[1] - 1,
       -- character = math.max(cursor[2] - inlay_instance.prior_delete, 0),
-      character = vim.fn.col("0")
+      character = vim.fn.col("0"),
     },
     ["end"] = {
       line = cursor[1] - 1,
-      character = vim.fn.col("$")
-    }
+      character = vim.fn.col("$"),
+    },
   }
 
-  local completion_text = (inlay_instance.line_before_cursor) .. inlay_instance.completion_text
-  local preview_text    = completion_text
-  local split           = vim.split(completion_text, "\n", { plain = true })
-  local label           = label_text(split[1], #split)
+  local completion_text = inlay_instance.line_before_cursor .. inlay_instance.completion_text
+  local preview_text = completion_text
+  local split = vim.split(completion_text, "\n", { plain = true })
+  local label = label_text(split[1], #split)
   -- local label           = u.trim_start(vim.split(completion_text, "\n", { plain = true })[1])
 
   -- print("Completion label:", label)
 
-  local items           = {
+  local items = {
     {
       label = label,
       kind = 1,
@@ -86,7 +86,7 @@ function source.complete(self, params, callback)
       filterText = nil,
       cmp = {
         kind_hl_group = "CmpItemKindSupermaven",
-        kind_text = 'Supermaven',
+        kind_text = "Supermaven",
       },
       textEdit = {
         newText = completion_text,
@@ -95,23 +95,21 @@ function source.complete(self, params, callback)
       },
       documentation = {
         kind = "markdown",
-        value = "```" ..
-            vim.bo.filetype ..
-            "\n" .. preview_text .. "\n```"
+        value = "```" .. vim.bo.filetype .. "\n" .. preview_text .. "\n```",
       },
-      dup = 0
-    }
+      dup = 0,
+    },
   }
 
   return callback({
     isIncomplete = false,
-    items = items
+    items = items,
   })
 end
 
 function source.new(client, opts)
   local self = setmetatable({
-    timer = vim.loop.new_timer()
+    timer = vim.loop.new_timer(),
   }, { __index = source })
 
   self.client = client

--- a/lua/supermaven-nvim/cmp.lua
+++ b/lua/supermaven-nvim/cmp.lua
@@ -1,5 +1,4 @@
 local CompletionPreview = require("supermaven-nvim.completion_preview")
--- local u = require("supermaven-nvim.util")
 
 local source = { executions = {}, }
 

--- a/lua/supermaven-nvim/commands.lua
+++ b/lua/supermaven-nvim/commands.lua
@@ -3,6 +3,22 @@ local api = require("supermaven-nvim.api")
 local M = {}
 
 M.setup = function()
+  vim.api.nvim_create_user_command("SupermavenStart", function()
+    api.start()
+  end, {})
+
+  vim.api.nvim_create_user_command("SupermavenStop", function()
+    api.stop()
+  end, {})
+
+  vim.api.nvim_create_user_command("SupermavenRestart", function()
+    api.restart()
+  end, {})
+
+  vim.api.nvim_create_user_command("SupermavenStatus", function()
+    vim.notify(string.format("Supermaven is %s", api.is_running() and "running" or "not running"))
+  end, {})
+
   vim.api.nvim_create_user_command("SupermavenUseFree", function()
     api.use_free_version()
   end, {})

--- a/lua/supermaven-nvim/commands.lua
+++ b/lua/supermaven-nvim/commands.lua
@@ -1,0 +1,19 @@
+local api = require("supermaven-nvim.api")
+
+local M = {}
+
+M.setup = function()
+  vim.api.nvim_create_user_command("SupermavenUseFree", function()
+    api.use_free_version()
+  end, {})
+
+  vim.api.nvim_create_user_command("SupermavenUsePro", function()
+    api.use_pro()
+  end, {})
+
+  vim.api.nvim_create_user_command("SupermavenLogout", function()
+    api.logout()
+  end, {})
+end
+
+return M

--- a/lua/supermaven-nvim/commands.lua
+++ b/lua/supermaven-nvim/commands.lua
@@ -15,6 +15,10 @@ M.setup = function()
     api.restart()
   end, {})
 
+  vim.api.nvim_create_user_command("SupermavenToggle", function()
+    api.toggle()
+  end, {})
+
   vim.api.nvim_create_user_command("SupermavenStatus", function()
     vim.notify(string.format("Supermaven is %s", api.is_running() and "running" or "not running"))
   end, {})

--- a/lua/supermaven-nvim/completion_preview.lua
+++ b/lua/supermaven-nvim/completion_preview.lua
@@ -2,21 +2,27 @@ local u = require("supermaven-nvim.util")
 
 local CompletionPreview = {
   inlay_instance = nil,
-  ns_id = vim.api.nvim_create_namespace('supermaven'),
+  ns_id = vim.api.nvim_create_namespace("supermaven"),
   suggestion_group = "Comment",
   disable_inline_completion = false,
 }
 
 CompletionPreview.__index = CompletionPreview
 
-function CompletionPreview:render_with_inlay(buffer, prior_delete, completion_text, line_after_cursor, line_before_cursor)
+function CompletionPreview:render_with_inlay(
+  buffer,
+  prior_delete,
+  completion_text,
+  line_after_cursor,
+  line_before_cursor
+)
   self:dispose_inlay()
 
   if not buffer then
     return
   end
 
-  if vim.api.nvim_get_mode().mode ~= 'i' then
+  if vim.api.nvim_get_mode().mode ~= "i" then
     return
   end
 
@@ -32,7 +38,7 @@ function CompletionPreview:render_with_inlay(buffer, prior_delete, completion_te
 
   local is_floating = (#line_after_cursor > 0) and (not u.contains(first_line, line_after_cursor))
 
-  if (is_floating) then
+  if is_floating then
     self:render_floating(first_line, opts, buf, line_before_cursor)
     completion_text = first_line
   else
@@ -145,12 +151,15 @@ function CompletionPreview.on_accept_suggestion(is_partial)
       ["end"] = {
         line = cursor[1] - 1,
         character = vim.fn.col("$"),
-      }
+      },
     }
 
     vim.api.nvim_feedkeys(vim.api.nvim_replace_termcodes("<Space><Left><Del>", true, false, true), "n", false)
-    vim.lsp.util.apply_text_edits({ { range = range, newText = completion_text } }, vim.api.nvim_get_current_buf(),
-      "utf-16")
+    vim.lsp.util.apply_text_edits(
+      { { range = range, newText = completion_text } },
+      vim.api.nvim_get_current_buf(),
+      "utf-16"
+    )
 
     local lines = u.line_count(completion_text)
     local last_line = u.get_last_line(completion_text)
@@ -171,8 +180,10 @@ end
 
 function CompletionPreview.has_suggestion()
   local inlay_instance = CompletionPreview:get_inlay_instance()
-  return inlay_instance ~= nil and inlay_instance.is_active and inlay_instance.completion_text ~= nil and
-      inlay_instance.completion_text ~= ""
+  return inlay_instance ~= nil
+    and inlay_instance.is_active
+    and inlay_instance.completion_text ~= nil
+    and inlay_instance.completion_text ~= ""
 end
 
 return CompletionPreview

--- a/lua/supermaven-nvim/config.lua
+++ b/lua/supermaven-nvim/config.lua
@@ -9,12 +9,20 @@ local default_config = {
   disable_keymaps = false
 }
 
-local M = {}
+local M = {
+  config = vim.deepcopy(default_config),
+}
 
-M.setup_config = function(args)
-  local config = vim.tbl_deep_extend("force", default_config, args)
-  return config
+M.setup = function(args)
+  M.config = vim.tbl_deep_extend("force", vim.deepcopy(default_config), args)
 end
 
-return M
+return setmetatable(M, {
+  __index = function(_, key)
+    if key == "setup" then
+      return M.setup
+    end
+    return rawget(M.config, key)
+  end,
+})
 

--- a/lua/supermaven-nvim/config.lua
+++ b/lua/supermaven-nvim/config.lua
@@ -9,7 +9,7 @@ local default_config = {
   disable_keymaps = false
 }
 
-M = {}
+local M = {}
 
 M.setup_config = function(args)
   local config = vim.tbl_deep_extend("force", default_config, args)

--- a/lua/supermaven-nvim/config.lua
+++ b/lua/supermaven-nvim/config.lua
@@ -6,7 +6,7 @@ local default_config = {
   },
   ignore_filetypes = {},
   disable_inline_completion = false,
-  disable_keymaps = false
+  disable_keymaps = false,
 }
 
 local M = {
@@ -25,4 +25,3 @@ return setmetatable(M, {
     return rawget(M.config, key)
   end,
 })
-

--- a/lua/supermaven-nvim/document_listener.lua
+++ b/lua/supermaven-nvim/document_listener.lua
@@ -1,25 +1,53 @@
 local binary = require("supermaven-nvim.binary.binary_handler")
 local preview = require("supermaven-nvim.completion_preview")
+local config = require("supermaven-nvim.config")
 
-vim.api.nvim_create_autocmd({"TextChanged", "TextChangedI"}, {
-  callback = function(event)
-    local file_name = event["file"]
-    local buffer = event["buf"]
-    if not file_name or not buffer then
-      return
+local M = {}
+
+M.setup = function()
+  vim.api.nvim_create_autocmd({"TextChanged", "TextChangedI"}, {
+    callback = function(event)
+      local file_name = event["file"]
+      local buffer = event["buf"]
+      if not file_name or not buffer then
+        return
+      end
+      binary:on_update(buffer, file_name, "text_changed")
     end
-    binary:on_update(buffer, file_name, "text_changed")
+  })
+
+  vim.api.nvim_create_autocmd({"CursorMoved", "CursorMovedI"}, {
+    callback = function(event)
+      local file_name = event["file"]
+      local buffer = event["buf"]
+      if not file_name or not buffer then
+        return
+      end
+      binary:on_update(buffer, file_name, "cursor")
+    end
+  })
+
+  vim.api.nvim_create_autocmd({"InsertLeave"}, {
+    callback = function(event)
+      preview:dispose_inlay()
+    end
+  })
+
+  if config.color and config.color.suggestion_color and config.color.cterm then
+    vim.api.nvim_create_autocmd({ "VimEnter", "ColorScheme" }, {
+      pattern = "*",
+      callback = function(event)
+        vim.api.nvim_set_hl(0, "SupermavenSuggestion", {
+          fg = config.color.suggestion_color,
+          ctermfg = config.color.cterm,
+        })
+        preview.suggestion_group = "SupermavenSuggestion"
+      end,
+    })
   end
-})
+end
 
-vim.api.nvim_create_autocmd({"CursorMoved", "CursorMovedI"}, {
-  callback = function(event)
-    local file_name = event["file"]
-    local buffer = event["buf"]
-    if not file_name or not buffer then
-      return
-    end
-    binary:on_update(buffer, file_name, "cursor")
+return M
   end
 })
 

--- a/lua/supermaven-nvim/document_listener.lua
+++ b/lua/supermaven-nvim/document_listener.lua
@@ -1,4 +1,3 @@
-local u = require("supermaven-nvim.util")
 local binary = require("supermaven-nvim.binary.binary_handler")
 local preview = require("supermaven-nvim.completion_preview")
 

--- a/lua/supermaven-nvim/init.lua
+++ b/lua/supermaven-nvim/init.lua
@@ -1,7 +1,7 @@
-local binary = require("supermaven-nvim.binary.binary_handler")
 local completion_preview = require("supermaven-nvim.completion_preview")
-local listener = require("supermaven-nvim.document_listener")
 local config = require("supermaven-nvim.config")
+local commands = require("supermaven-nvim.commands")
+local api = require("supermaven-nvim.api")
 
 local M = {}
 
@@ -29,20 +29,7 @@ M.setup = function(args)
     end
   end
 
-  binary:start_binary()
-
-  if config.color and config.color.suggestion_color and config.color.cterm then
-    vim.api.nvim_create_autocmd({ "VimEnter", "ColorScheme" }, {
-      pattern = "*",
-      callback = function(event)
-        vim.api.nvim_set_hl(0, "SupermavenSuggestion", {
-          fg = config.color.suggestion_color,
-          ctermfg = config.color.cterm,
-        })
-        completion_preview.suggestion_group = "SupermavenSuggestion"
-      end
-    })
-  end
+  commands.setup()
 
   local cmp_ok, cmp = pcall(require, "cmp")
   if cmp_ok then
@@ -55,6 +42,8 @@ M.setup = function(args)
         vim.log.levels.WARN)
     end
   end
+
+  api.start()
 end
 
 return M

--- a/lua/supermaven-nvim/init.lua
+++ b/lua/supermaven-nvim/init.lua
@@ -4,7 +4,7 @@ local u = require("supermaven-nvim.util")
 local listener = require("supermaven-nvim.document_listener")
 local config = require("supermaven-nvim.config")
 
-M = {}
+local M = {}
 
 M.setup = function(args)
   local config_settings = config.setup_config(args)

--- a/lua/supermaven-nvim/init.lua
+++ b/lua/supermaven-nvim/init.lua
@@ -7,38 +7,38 @@ local config = require("supermaven-nvim.config")
 local M = {}
 
 M.setup = function(args)
-  local config_settings = config.setup_config(args)
+  config.setup(args)
 
-  if config_settings.disable_inline_completion then
+  if config.disable_inline_completion then
     completion_preview.disable_inline_completion = true
-  elseif not config_settings.disable_keymaps then
-    if config_settings.keymaps.accept_suggestion ~= nil then
-      local accept_suggestion_key = config_settings.keymaps.accept_suggestion
+  elseif not config.disable_keymaps then
+    if config.keymaps.accept_suggestion ~= nil then
+      local accept_suggestion_key = config.keymaps.accept_suggestion
       vim.keymap.set('i', accept_suggestion_key, completion_preview.on_accept_suggestion,
         { noremap = true, silent = true })
     end
 
-    if config_settings.keymaps.accept_word ~= nil then
-      local accept_word_key = config_settings.keymaps.accept_word
+    if config.keymaps.accept_word ~= nil then
+      local accept_word_key = config.keymaps.accept_word
       vim.keymap.set('i', accept_word_key, completion_preview.on_accept_suggestion_word,
         { noremap = true, silent = true })
     end
 
-    if config_settings.keymaps.clear_suggestion ~= nil then
-      local clear_suggestion_key = config_settings.keymaps.clear_suggestion
+    if config.keymaps.clear_suggestion ~= nil then
+      local clear_suggestion_key = config.keymaps.clear_suggestion
       vim.keymap.set('i', clear_suggestion_key, completion_preview.on_dispose_inlay, { noremap = true, silent = true })
     end
   end
 
-  binary:start_binary(config_settings.ignore_filetypes or {})
+  binary:start_binary()
 
-  if config_settings.color and config_settings.color.suggestion_color and config_settings.color.cterm then
+  if config.color and config.color.suggestion_color and config.color.cterm then
     vim.api.nvim_create_autocmd({ "VimEnter", "ColorScheme" }, {
       pattern = "*",
       callback = function(event)
         vim.api.nvim_set_hl(0, "SupermavenSuggestion", {
-          fg = config_settings.color.suggestion_color,
-          ctermfg = config_settings.color.cterm,
+          fg = config.color.suggestion_color,
+          ctermfg = config.color.cterm,
         })
         completion_preview.suggestion_group = "SupermavenSuggestion"
       end
@@ -50,7 +50,7 @@ M.setup = function(args)
     local cmp_source = require("supermaven-nvim.cmp")
     cmp.register_source("supermaven", cmp_source.new())
   else
-    if config_settings.disable_inline_completion then
+    if config.disable_inline_completion then
       vim.notify(
         "nvim-cmp is not available, but inline completion is disabled. Supermaven nvim-cmp source will not be registered.",
         vim.log.levels.WARN)

--- a/lua/supermaven-nvim/init.lua
+++ b/lua/supermaven-nvim/init.lua
@@ -1,6 +1,5 @@
 local binary = require("supermaven-nvim.binary.binary_handler")
 local completion_preview = require("supermaven-nvim.completion_preview")
-local u = require("supermaven-nvim.util")
 local listener = require("supermaven-nvim.document_listener")
 local config = require("supermaven-nvim.config")
 

--- a/lua/supermaven-nvim/init.lua
+++ b/lua/supermaven-nvim/init.lua
@@ -13,19 +13,27 @@ M.setup = function(args)
   elseif not config.disable_keymaps then
     if config.keymaps.accept_suggestion ~= nil then
       local accept_suggestion_key = config.keymaps.accept_suggestion
-      vim.keymap.set('i', accept_suggestion_key, completion_preview.on_accept_suggestion,
-        { noremap = true, silent = true })
+      vim.keymap.set(
+        "i",
+        accept_suggestion_key,
+        completion_preview.on_accept_suggestion,
+        { noremap = true, silent = true }
+      )
     end
 
     if config.keymaps.accept_word ~= nil then
       local accept_word_key = config.keymaps.accept_word
-      vim.keymap.set('i', accept_word_key, completion_preview.on_accept_suggestion_word,
-        { noremap = true, silent = true })
+      vim.keymap.set(
+        "i",
+        accept_word_key,
+        completion_preview.on_accept_suggestion_word,
+        { noremap = true, silent = true }
+      )
     end
 
     if config.keymaps.clear_suggestion ~= nil then
       local clear_suggestion_key = config.keymaps.clear_suggestion
-      vim.keymap.set('i', clear_suggestion_key, completion_preview.on_dispose_inlay, { noremap = true, silent = true })
+      vim.keymap.set("i", clear_suggestion_key, completion_preview.on_dispose_inlay, { noremap = true, silent = true })
     end
   end
 
@@ -39,7 +47,8 @@ M.setup = function(args)
     if config.disable_inline_completion then
       vim.notify(
         "nvim-cmp is not available, but inline completion is disabled. Supermaven nvim-cmp source will not be registered.",
-        vim.log.levels.WARN)
+        vim.log.levels.WARN
+      )
     end
   end
 

--- a/lua/supermaven-nvim/textual.lua
+++ b/lua/supermaven-nvim/textual.lua
@@ -1,5 +1,5 @@
 local u = require("supermaven-nvim.util")
-M = {}
+local M = {}
 
 local function find_first_non_empty_newline(s)
   local seen_non_whitespace = false
@@ -110,7 +110,7 @@ local function finish_completion(output, deletion, dedent, params)
         is_incomplete = false,
       }
     end
-    
+
     if not is_all_whitespace_and_closing_paren(params.line_after_cursor) then
       return nil
     end
@@ -128,7 +128,7 @@ local function finish_completion(output, deletion, dedent, params)
       }
     end
   end
-  
+
   return nil
 end
 
@@ -165,7 +165,7 @@ function M.derive_completion(completion, completion_params)
   if index ~= nil then
     output = output:sub(1, index)
   end
-  
+
   return finish_completion(output, deletion, dedent, completion_params)
 end
 

--- a/lua/supermaven-nvim/util.lua
+++ b/lua/supermaven-nvim/util.lua
@@ -1,4 +1,4 @@
-M = {}
+local M = {}
 
 function M.print(msg)
   vim.api.nvim_out_write(msg .. "\n")

--- a/lua/supermaven-nvim/util.lua
+++ b/lua/supermaven-nvim/util.lua
@@ -56,9 +56,9 @@ end
 function M.removeAfterNewline(str)
   local newlinePos = string.find(str, "\n")
   if newlinePos then
-      return string.sub(str, 1, newlinePos - 1)
+    return string.sub(str, 1, newlinePos - 1)
   else
-      return str
+    return str
   end
 end
 
@@ -93,18 +93,18 @@ function M.get_home_directory()
 end
 
 function M.get_cursor_prefix(bufnr, cursor)
-    if not vim.api.nvim_buf_is_valid(bufnr) then
-        return ""
-    end
+  if not vim.api.nvim_buf_is_valid(bufnr) then
+    return ""
+  end
 
-    local prefix = vim.api.nvim_buf_get_text(bufnr, 0, 0, cursor[1] - 1, cursor[2], {})
-    local text = table.concat(prefix, "\n")
-    return text
+  local prefix = vim.api.nvim_buf_get_text(bufnr, 0, 0, cursor[1] - 1, cursor[2], {})
+  local text = table.concat(prefix, "\n")
+  return text
 end
 
 function M.get_cursor_suffix(bufnr, cursor)
   if not vim.api.nvim_buf_is_valid(bufnr) then
-        return ""
+    return ""
   end
 
   local suffix = vim.api.nvim_buf_get_text(bufnr, cursor[1], cursor[2], -1, -1, {})


### PR DESCRIPTION
Hello! This is a small refactor of the project which improves modularity and the management of resources.

- Makes it possible to stop supermaven-nvim, which kills the binary and removes all of the autocommands (Fixes #36)
- Modularizes the code by introducing `supermaven-nvim.api` and `supermaven-nvim.commands` modules
- Adds `SupermavenStart`, `SupermavenStop`, `SupermavenRestart`, `SupermavenToggle`, and `SupermavenStatus` commands
- Makes `supermaven-nvim.config` the source of truth for the current config, rather than passing a table around from `supermaven-nvim.init`
- Applies stylua formatting
- Removes unused imports
- Updates README to document these changes

Because this touches a lot of lines of code, this probably conflicts with several other open PRs. I'm happy to split this up into separate PRs, or rebase on top of other PRs if desired.

Supersedes #40 