### PR TITLE
feat!: `ignore_filetypes` as `string[]`

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ require("supermaven-nvim").setup({
     clear_suggestion = "<C-]>",
     accept_word = "<C-j>",
   },
-  ignore_filetypes = { cpp = true },
+  ignore_filetypes = { "cpp" },
   color = {
     suggestion_color = "#ffffff",
     cterm = 244,

--- a/lua/supermaven-nvim/binary/binary_handler.lua
+++ b/lua/supermaven-nvim/binary/binary_handler.lua
@@ -287,7 +287,7 @@ function BinaryLifecycle:poll_once()
     self.wants_polling = false
     return
   end
-  if config.ignore_filetypes[vim.bo.filetype] then
+  if vim.tbl_contains(config.ignore_filetypes, vim.bo.filetype) then
     return
   end
   self.wants_polling = true


### PR DESCRIPTION
BREAKING CHANGE: now `ignore_filetypes` is an array of strings

- Before:

```lua
ignore_filetypes = {
  cpp = true,
  help = true,
  ...
}
```

- Now:

```lua
ignore_filetypes = { "cpp", "help", ... }
```