### PR TITLE
feat(#24): tagging conflicted PR action

### DIFF
--- a/.github/workflows/tag-conflicts.yml
+++ b/.github/workflows/tag-conflicts.yml
@@ -1,0 +1,23 @@
+name: Tag PRs with merge conflicts
+
+on:
+  # So that PRs touching the same files as the push are updated
+  push:
+  # So that the `dirtyLabel` is removed if conflicts are resolve
+  # We recommend `pull_request_target` so that github secrets are available.
+  # In `pull_request` we wouldn't be able to change labels of fork PRs
+  pull_request_target:
+    types: [synchronize]
+
+jobs:
+  main:
+    runs-on: ubuntu-latest
+    steps:
+      - name: check if prs are dirty
+        uses: eps1lon/actions-label-merge-conflict@releases/2.x
+        with:
+          dirtyLabel: conflicts
+          removeOnDirtyLabel: conflicts
+          repoToken: "${{ secrets.GITHUB_TOKEN }}"
+          commentOnDirty: "⚠️ This PR has conflicts. Please, solve them."
+          commentOnClean: "✅ The conflict have been solved! Ready to review."


### PR DESCRIPTION
With this PR, when there is a conflict in a PR it will notify that it has conflicts and tag it with `conflicts` so it easier to know when a PR has conflicts without having to check every time in case the submitted PR has or hasn't conflicting code.

For more information about this action:
- <https://github.com/eps1lon/actions-label-merge-conflict>