### PR TITLE
feat(#49): exposing `suggestion_group` in config settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,8 @@ The `ignore_filetypes` table is used to ignore filetypes when using supermaven-n
 
 `suggestion_color` and `cterm` options can be used to set the color of the suggestion text.
 
+`suggestion_group` is used to set the highlight group for the suggestion text. If `suggestion_group` is set, it will override `suggestion_color` and `cterm` values.
+
 ```lua
 require("supermaven-nvim").setup({
   keymaps = {
@@ -49,6 +51,7 @@ require("supermaven-nvim").setup({
   color = {
     suggestion_color = "#ffffff",
     cterm = 244,
+    suggestion_group = "Comment", -- if `suggestion_group` is set, it will override `suggestion_color` and `cterm`
   },
   disable_inline_completion = false, -- disables inline completion for use with cmp
   disable_keymaps = false -- disables built in keymaps for more manual control

--- a/lua/supermaven-nvim/completion_preview.lua
+++ b/lua/supermaven-nvim/completion_preview.lua
@@ -1,9 +1,15 @@
 local u = require("supermaven-nvim.util")
+local config = require("supermaven-nvim.config")
+
+local suggestion_group = "Comment"
+if config.config.color ~= nil then
+  suggestion_group = config.config.color.suggestion_group or "Comment"
+end
 
 local CompletionPreview = {
   inlay_instance = nil,
   ns_id = vim.api.nvim_create_namespace("supermaven"),
-  suggestion_group = "Comment",
+  suggestion_group,
   disable_inline_completion = false,
 }
 

--- a/lua/supermaven-nvim/document_listener.lua
+++ b/lua/supermaven-nvim/document_listener.lua
@@ -40,14 +40,31 @@ M.setup = function()
     end,
   })
 
-  if config.color and config.color.suggestion_color and config.color.cterm then
+  if config.color then
     vim.api.nvim_create_autocmd({ "VimEnter", "ColorScheme" }, {
       group = M.augroup,
       pattern = "*",
       callback = function(event)
+        if config.color.suggestion_group then
+          vim.api.nvim_set_hl(0, "SupermavenSuggestion", {
+            link = config.color.suggestion_group,
+          })
+        elseif config.color.suggestion_color and config.color.cterm then
+          vim.api.nvim_set_hl(0, "SupermavenSuggestion", {
+            fg = config.color.suggestion_color,
+            ctermfg = config.color.cterm,
+          })
+        end
+        preview.suggestion_group = "SupermavenSuggestion"
+      end,
+    })
+  else
+    vim.api.nvim_create_autocmd({ "VimEnter", "ColorScheme" }, {
+      group = M.augroup,
+      pattern = "*",
+      callback = function(_)
         vim.api.nvim_set_hl(0, "SupermavenSuggestion", {
-          fg = config.color.suggestion_color,
-          ctermfg = config.color.cterm,
+          link = preview.suggestion_group,
         })
         preview.suggestion_group = "SupermavenSuggestion"
       end,


### PR DESCRIPTION
With this changes `suggestion_group` will be exposed to the config under `config.color` like:

```lua
require("supermaven-nvim").setup({
  color = {
    suggestion_group = "Comment",
  },
})
```

Allowing users to change it in an easier way.

---

https://github.com/supermaven-inc/supermaven-nvim/assets/71392160/1fc06cc3-79ce-49c3-84cd-50bb3ca49692

Closes #49.