### PR TITLE
fix(#52): Set the colorscheme when lazyloading the plugin

### DIFF
--- a/lua/supermaven-nvim/document_listener.lua
+++ b/lua/supermaven-nvim/document_listener.lua
@@ -41,7 +41,14 @@ M.setup = function()
   })
 
   if config.color and config.color.suggestion_color and config.color.cterm then
-    vim.api.nvim_create_autocmd({ "VimEnter", "ColorScheme" }, {
+
+    vim.api.nvim_set_hl(0, "SupermavenSuggestion", {
+      fg = config.color.suggestion_color,
+      ctermfg = config.color.cterm,
+    })
+    preview.suggestion_group = "SupermavenSuggestion"
+
+    vim.api.nvim_create_autocmd({ "ColorScheme" }, {
       group = M.augroup,
       pattern = "*",
       callback = function(event)


### PR DESCRIPTION
When the plugin gets loaded we call the function first, so VimEnter is not needed anymore.
If you would like to fix this another way, please let me know.
fixes #52 