### PR TITLE
feat(#48): `accept_line` keymap option

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ require("supermaven-nvim").setup({
     accept_suggestion = "<Tab>",
     clear_suggestion = "<C-]>",
     accept_word = "<C-j>",
+    accept_line = "<C-l>",
   },
   ignore_filetypes = { cpp = true },
   color = {

--- a/lua/supermaven-nvim/completion_preview.lua
+++ b/lua/supermaven-nvim/completion_preview.lua
@@ -111,7 +111,12 @@ function CompletionPreview:accept_completion_text(is_partial)
 
   if completion_text ~= nil then
     if is_partial then
-      completion_text = u.to_next_word(completion_text)
+      if is_partial.word then
+        completion_text = u.to_next_word(completion_text)
+      end
+      if is_partial.line then
+        completion_text = u.to_next_line(completion_text)
+      end
     end
     return { completion_text = completion_text, prior_delete = prior_delete, is_active = current_instance.is_active }
   end
@@ -171,7 +176,11 @@ function CompletionPreview.on_accept_suggestion(is_partial)
 end
 
 function CompletionPreview.on_accept_suggestion_word()
-  CompletionPreview.on_accept_suggestion(true)
+  CompletionPreview.on_accept_suggestion({ word = true })
+end
+
+function CompletionPreview.on_accept_suggestion_line()
+  CompletionPreview.on_accept_suggestion({ line = true })
 end
 
 function CompletionPreview.on_dispose_inlay()

--- a/lua/supermaven-nvim/config.lua
+++ b/lua/supermaven-nvim/config.lua
@@ -3,6 +3,7 @@ local default_config = {
     accept_suggestion = "<Tab>",
     clear_suggestion = "<C-]>",
     accept_word = "<C-j>",
+    accept_line = "<C-l>",
   },
   ignore_filetypes = {},
   disable_inline_completion = false,

--- a/lua/supermaven-nvim/init.lua
+++ b/lua/supermaven-nvim/init.lua
@@ -31,6 +31,16 @@ M.setup = function(args)
       )
     end
 
+    if config.keymaps.accept_line ~= nil then
+      local accept_line_key = config.keymaps.accept_line
+      vim.keymap.set(
+        "i",
+        accept_line_key,
+        completion_preview.on_accept_suggestion_line,
+        { noremap = true, silent = true }
+      )
+    end
+
     if config.keymaps.clear_suggestion ~= nil then
       local clear_suggestion_key = config.keymaps.clear_suggestion
       vim.keymap.set("i", clear_suggestion_key, completion_preview.on_dispose_inlay, { noremap = true, silent = true })

--- a/lua/supermaven-nvim/util.lua
+++ b/lua/supermaven-nvim/util.lua
@@ -190,9 +190,14 @@ function M.to_next_word(str)
 end
 
 function M.to_next_line(str)
-  local match = str:match("^.-\n")
+  local match = str:match("\n")
   if match ~= nil then
-    return match
+    local lines = vim.split(str, "\n")
+    if lines[1] ~= "" then
+      return lines[1]
+    else
+      return "\n" .. lines[2]
+    end
   end
   return str
 end

--- a/lua/supermaven-nvim/util.lua
+++ b/lua/supermaven-nvim/util.lua
@@ -189,4 +189,12 @@ function M.to_next_word(str)
   return str
 end
 
+function M.to_next_line(str)
+  local match = str:match("^.-\n")
+  if match ~= nil then
+    return match
+  end
+  return str
+end
+
 return M


### PR DESCRIPTION
With this PR `accept_line` keymap is introduced with `<C-l>` as default because `l -> line`.

Accepts the next suggested line by looking for end of line.

- [x] Updated `README.md` with the keymap changes.

---

https://github.com/supermaven-inc/supermaven-nvim/assets/71392160/88efc25f-2626-4fed-a1dd-73d8b96f5e1d

Closes #48.