### PR TITLE
feat(#55): support for `dot-repeat`

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ require("supermaven-nvim").setup({
   },
   disable_inline_completion = false, -- disables inline completion for use with cmp
   disable_keymaps = false -- disables built in keymaps for more manual control
+  dot_repeat = false -- enables repeating the last suggestion with `.`
 })
 ```
 

--- a/lua/supermaven-nvim/config.lua
+++ b/lua/supermaven-nvim/config.lua
@@ -7,6 +7,7 @@ local default_config = {
   ignore_filetypes = {},
   disable_inline_completion = false,
   disable_keymaps = false,
+  dot_repeat = false,
 }
 
 local M = {

--- a/lua/supermaven-nvim/init.lua
+++ b/lua/supermaven-nvim/init.lua
@@ -21,6 +21,10 @@ M.setup = function(args)
       )
     end
 
+    if config.dot_repeat then
+      vim.keymap.set("n", ".", completion_preview.on_repeat_suggestion, { noremap = true, silent = true })
+    end
+
     if config.keymaps.accept_word ~= nil then
       local accept_word_key = config.keymaps.accept_word
       vim.keymap.set(


### PR DESCRIPTION
With these changes now with `config.dot_repeat = true` it will repeat the last accepted suggestion under the cursor using `.` in **Normal Mode**.

```lua
require("supermaven-nvim").setup({
  dot_repeat = true, -- default as false
})
```

- [x] Updated documentation with changes

**Possible changes**:
- https://github.com/supermaven-inc/supermaven-nvim/issues/55#issuecomment-2155391926

---

https://github.com/supermaven-inc/supermaven-nvim/assets/71392160/5cbfb92c-1e69-460c-9801-cde5f39a751b

Closes #55.