### PR TITLE
feat(#57): disable `supermaven-nvim` on condition

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,8 +52,28 @@ require("supermaven-nvim").setup({
   },
   disable_inline_completion = false, -- disables inline completion for use with cmp
   disable_keymaps = false -- disables built in keymaps for more manual control
+  condition = function()
+    return false
+  end -- condition to check for stopping supermaven, `true` means to stop supermaven when the condition is true.
 })
 ```
+
+### Disabling supermaven-nvim conditionally
+
+By default, supermaven-nvim will always run unless `condition` function returns true or
+current filetype is in `ignore_filetypes`.
+
+You can disable supermaven-nvim conditionally by setting `condition` function to return true.
+
+```lua
+require("supermaven-nvim").setup({
+  condition = function()
+    return string.match(vim.fn.expand("%:t"), "foo.sh")
+  end,
+})
+```
+
+This will disable supermaven-nvim for files with the name `foo.sh` in it, e.g. `myscriptfoo.sh`.
 
 ### Using with nvim-cmp
 

--- a/lua/supermaven-nvim/binary/binary_handler.lua
+++ b/lua/supermaven-nvim/binary/binary_handler.lua
@@ -72,6 +72,9 @@ function BinaryLifecycle:greeting_message()
 end
 
 function BinaryLifecycle:on_update(buffer, file_name, event_type)
+  if config.condition() then
+    return
+  end
   local buffer_text = u.get_text(buffer)
   local updates = {
     {
@@ -287,6 +290,11 @@ function BinaryLifecycle:poll_once()
     self.wants_polling = false
     return
   end
+
+  if config.condition() then
+    return
+  end
+
   if config.ignore_filetypes[vim.bo.filetype] then
     return
   end

--- a/lua/supermaven-nvim/binary/binary_handler.lua
+++ b/lua/supermaven-nvim/binary/binary_handler.lua
@@ -72,9 +72,6 @@ function BinaryLifecycle:greeting_message()
 end
 
 function BinaryLifecycle:on_update(buffer, file_name, event_type)
-  if config.condition() then
-    return
-  end
   local buffer_text = u.get_text(buffer)
   local updates = {
     {
@@ -290,11 +287,6 @@ function BinaryLifecycle:poll_once()
     self.wants_polling = false
     return
   end
-
-  if config.condition() then
-    return
-  end
-
   if config.ignore_filetypes[vim.bo.filetype] then
     return
   end

--- a/lua/supermaven-nvim/config.lua
+++ b/lua/supermaven-nvim/config.lua
@@ -7,6 +7,9 @@ local default_config = {
   ignore_filetypes = {},
   disable_inline_completion = false,
   disable_keymaps = false,
+  condition = function()
+    return false
+  end,
 }
 
 local M = {

--- a/lua/supermaven-nvim/document_listener.lua
+++ b/lua/supermaven-nvim/document_listener.lua
@@ -21,6 +21,26 @@ M.setup = function()
     end,
   })
 
+  vim.api.nvim_create_autocmd({ "BufEnter" }, {
+    callback = function(_)
+      local ok, api = pcall(require, "supermaven-nvim.api")
+      if not ok then
+        return
+      end
+      if config.condition() then
+        if api.is_running() then
+          api.stop()
+          return
+        end
+      else
+        if api.is_running() then
+          return
+        end
+        api.start()
+      end
+    end,
+  })
+
   vim.api.nvim_create_autocmd({ "CursorMoved", "CursorMovedI" }, {
     group = M.augroup,
     callback = function(event)


### PR DESCRIPTION
With these changes the user can stop `supermaven` conditionally for example, if the user wants files like `bash_private.sh` to not be running but want any other `.sh` files to have `supermaven` running it can do it with the following configuration.

```lua
require("supermaven-nvim").setup({
  condition = function()
    return string.match(vim.fn.expand(":t"), "_private.sh")
  end,
})
```

- [x] Updated `README.md` with changes

---

For this demo I used:

```lua
require("supermaven-nvim").setup({
  condition = function()
    return vim.fn.expand(":t:r") == "api"
  end,
})
```

https://github.com/supermaven-inc/supermaven-nvim/assets/71392160/a1efb698-8e5b-49a2-af39-d2b5887fc492

> [!NOTE]
> It runs on `lua` files except in `api.lua` because the filename is `api`.

Closes #57.