### PR TITLE
fix(logger): improve `log_level` control

### DIFF
--- a/lua/supermaven-nvim/logger.lua
+++ b/lua/supermaven-nvim/logger.lua
@@ -69,8 +69,10 @@ function log:add_entry(level, msg)
   end
 
   self:write_log_file(level, msg)
-  if level ~= "error" and level ~= "warn" then
-    print(self.__notify_fmt(msg))
+  if conf.log_level ~= "error" and conf.log_level ~= "warn" then
+    if level ~= "error" and level ~= "warn" then
+      print(self.__notify_fmt(msg))
+    end
   end
 end
 


### PR DESCRIPTION
If `log_level` is set to anything other than `"warn"` or `"error"`, print information if is not unset with `"off"`.

This lets users have better control if the want all kinds of information, like `Starting Supermaven ...` or just the warns and errors.

Fixes #70.