### PR TITLE
Support array for ignore_filetype

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ require("supermaven-nvim").setup({
     clear_suggestion = "<C-]>",
     accept_word = "<C-j>",
   },
-  ignore_filetypes = { cpp = true },
+  ignore_filetypes = { cpp = true }, -- or { "cpp", }
   color = {
     suggestion_color = "#ffffff",
     cterm = 244,

--- a/lua/supermaven-nvim/binary/binary_handler.lua
+++ b/lua/supermaven-nvim/binary/binary_handler.lua
@@ -73,7 +73,7 @@ function BinaryLifecycle:greeting_message()
 end
 
 function BinaryLifecycle:on_update(buffer, file_name, event_type)
-  if config.ignore_filetypes[vim.bo.ft] then
+  if config.ignore_filetypes[vim.bo.ft] or vim.tbl_contains(config.ignore_filetypes, vim.bo.filetype) then
     return
   end
   local buffer_text = u.get_text(buffer)
@@ -288,7 +288,7 @@ function BinaryLifecycle:provide_inline_completion_items(buffer, cursor, context
 end
 
 function BinaryLifecycle:poll_once()
-  if config.ignore_filetypes[vim.bo.ft] then
+  if config.ignore_filetypes[vim.bo.ft] or vim.tbl_contains(config.ignore_filetypes, vim.bo.filetype) then
     return
   end
   local now = vim.loop.now()


### PR DESCRIPTION
Allows `ignore_filetypes` to take in an array of strings rather than key-value pairs