### PR TITLE
feat: add deprecated `api` to `util`

### DIFF
--- a/lua/supermaven-nvim/api.lua
+++ b/lua/supermaven-nvim/api.lua
@@ -1,4 +1,5 @@
 local binary = require("supermaven-nvim.binary.binary_handler")
+local u = require("supermaven-nvim.util")
 local listener = require("supermaven-nvim.document_listener")
 local log = require("supermaven-nvim.logger")
 
@@ -69,7 +70,7 @@ end
 M.clear_log = function()
   local log_path = log:get_log_path()
   if log_path ~= nil then
-    vim.loop.fs_unlink(log_path)
+    u.uv.fs_unlink(log_path)
   else
     log:warn("No log file found to remove!")
   end

--- a/lua/supermaven-nvim/api.lua
+++ b/lua/supermaven-nvim/api.lua
@@ -1,7 +1,9 @@
 local binary = require("supermaven-nvim.binary.binary_handler")
-local u = require("supermaven-nvim.util")
 local listener = require("supermaven-nvim.document_listener")
 local log = require("supermaven-nvim.logger")
+local u = require("supermaven-nvim.util")
+
+local loop = u.uv
 
 local M = {}
 
@@ -70,7 +72,7 @@ end
 M.clear_log = function()
   local log_path = log:get_log_path()
   if log_path ~= nil then
-    u.uv.fs_unlink(log_path)
+    loop.fs_unlink(log_path)
   else
     log:warn("No log file found to remove!")
   end

--- a/lua/supermaven-nvim/binary/binary_fetcher.lua
+++ b/lua/supermaven-nvim/binary/binary_fetcher.lua
@@ -1,10 +1,13 @@
 local log = require("supermaven-nvim.logger")
 local u = require("supermaven-nvim.util")
+
+local loop = u.uv
+
 local BinaryFetcher = {
   binary_path = nil,
   binary_url = nil,
-  os_uname = u.uv.os_uname(),
-  homedir = u.uv.os_homedir(),
+  os_uname = loop.os_uname(),
+  homedir = loop.os_homedir(),
 }
 
 local function generate_temp_path(n)
@@ -74,7 +77,7 @@ end
 
 function BinaryFetcher:fetch_binary()
   local local_binary_path = self:local_binary_path()
-  local status = u.uv.fs_stat(local_binary_path)
+  local status = loop.fs_stat(local_binary_path)
   if status ~= nil then
     return local_binary_path
   else
@@ -117,7 +120,7 @@ function BinaryFetcher:fetch_binary()
     log:error("sm-agent download failed")
     return nil
   end
-  u.uv.fs_chmod(local_binary_path, 493)
+  loop.fs_chmod(local_binary_path, 493)
   return local_binary_path
 end
 

--- a/lua/supermaven-nvim/binary/binary_fetcher.lua
+++ b/lua/supermaven-nvim/binary/binary_fetcher.lua
@@ -1,9 +1,10 @@
 local log = require("supermaven-nvim.logger")
+local u = require("supermaven-nvim.util")
 local BinaryFetcher = {
   binary_path = nil,
   binary_url = nil,
-  os_uname = vim.loop.os_uname(),
-  homedir = vim.loop.os_homedir(),
+  os_uname = u.uv.os_uname(),
+  homedir = u.uv.os_homedir(),
 }
 
 local function generate_temp_path(n)
@@ -73,7 +74,7 @@ end
 
 function BinaryFetcher:fetch_binary()
   local local_binary_path = self:local_binary_path()
-  local status = vim.loop.fs_stat(local_binary_path)
+  local status = u.uv.fs_stat(local_binary_path)
   if status ~= nil then
     return local_binary_path
   else
@@ -116,7 +117,7 @@ function BinaryFetcher:fetch_binary()
     log:error("sm-agent download failed")
     return nil
   end
-  vim.loop.fs_chmod(local_binary_path, 493)
+  u.uv.fs_chmod(local_binary_path, 493)
   return local_binary_path
 end
 

--- a/lua/supermaven-nvim/binary/binary_handler.lua
+++ b/lua/supermaven-nvim/binary/binary_handler.lua
@@ -1,6 +1,6 @@
-local loop = vim.loop
 local api = vim.api
 local u = require("supermaven-nvim.util")
+local loop = u.uv
 local textual = require("supermaven-nvim.textual")
 local config = require("supermaven-nvim.config")
 local preview = require("supermaven-nvim.completion_preview")
@@ -283,7 +283,7 @@ function BinaryLifecycle:provide_inline_completion_items(buffer, cursor, context
   self.buffer = buffer
   self.cursor = cursor
   self.last_context = context
-  self.last_provide_time = vim.loop.now()
+  self.last_provide_time = loop.now()
   self:poll_once()
 end
 
@@ -291,7 +291,7 @@ function BinaryLifecycle:poll_once()
   if config.ignore_filetypes[vim.bo.ft] or vim.tbl_contains(config.ignore_filetypes, vim.bo.filetype) then
     return
   end
-  local now = vim.loop.now()
+  local now = loop.now()
   if now - self.last_provide_time > 5 * 1000 then
     self.wants_polling = false
     return

--- a/lua/supermaven-nvim/binary/binary_handler.lua
+++ b/lua/supermaven-nvim/binary/binary_handler.lua
@@ -470,13 +470,8 @@ function BinaryLifecycle:open_popup(message, include_free)
 
   local width = 0
   local height = 0
-  if vim.version().minor >= 10 then
-    width = vim.api.nvim_get_option_value("columns", { scope = "local" })
-    height = vim.api.nvim_get_option_value("lines", { scope = "local" })
-  else
-    width = vim.api.nvim_get_option("columns")
-    height = vim.api.nvim_get_option("lines")
-  end
+  width = u.nvim_get_option_value("columns", { scope = "local" })
+  height = u.nvim_get_option_value("lines", { scope = "local" })
 
   local intro_message = "Please visit the following URL to set up Supermaven Pro"
   if include_free then
@@ -501,13 +496,8 @@ function BinaryLifecycle:open_popup(message, include_free)
 
   local win = vim.api.nvim_open_win(buf, true, opts)
   vim.api.nvim_buf_set_lines(buf, 0, -1, false, { intro_message, "", message .. " " })
-  if vim.version().minor >= 10 then
-    vim.api.nvim_set_option_value("winhl", "Normal:Normal", { scope = "local", win = win })
-    vim.api.nvim_set_option_value("wrap", true, { scope = "local", win = win })
-  else
-    vim.api.nvim_win_set_option(win, "winhl", "Normal:Normal")
-    vim.api.nvim_win_set_option(win, "wrap", true)
-  end
+  u.nvim_set_option_value("winhl", "Normal:Normal", { scope = "local", win = win })
+  u.nvim_set_option_value("wrap", true, { scope = "local", win = win })
 
   self.win = win
 end

--- a/lua/supermaven-nvim/cmp.lua
+++ b/lua/supermaven-nvim/cmp.lua
@@ -1,6 +1,8 @@
 local CompletionPreview = require("supermaven-nvim.completion_preview")
 local u = require("supermaven-nvim.util")
 
+local loop = u.uv
+
 local source = { executions = {} }
 
 local label_text = function(text, lines)
@@ -110,7 +112,7 @@ end
 
 function source.new(client, opts)
   local self = setmetatable({
-    timer = u.uv.new_timer(),
+    timer = loop.new_timer(),
   }, { __index = source })
 
   self.client = client

--- a/lua/supermaven-nvim/cmp.lua
+++ b/lua/supermaven-nvim/cmp.lua
@@ -1,4 +1,5 @@
 local CompletionPreview = require("supermaven-nvim.completion_preview")
+local u = require("supermaven-nvim.util")
 
 local source = { executions = {} }
 
@@ -109,7 +110,7 @@ end
 
 function source.new(client, opts)
   local self = setmetatable({
-    timer = vim.loop.new_timer(),
+    timer = u.uv.new_timer(),
   }, { __index = source })
 
   self.client = client

--- a/lua/supermaven-nvim/logger.lua
+++ b/lua/supermaven-nvim/logger.lua
@@ -1,5 +1,6 @@
 ---@diagnostic disable: missing-parameter
 local c = require("supermaven-nvim.config")
+local u = require("supermaven-nvim.util")
 
 ---@class Log
 local log = {}
@@ -7,7 +8,7 @@ local log = {}
 ---@alias LogLevel "off" | "trace" | "debug" | "info" | "warn" | "error" | "log"
 
 local join_path = function(...)
-  local is_windows = vim.loop.os_uname().version:match("Windows") -- could be "Windows" or "Windows_NT"
+  local is_windows = u.uv.os_uname().version:match("Windows") -- could be "Windows" or "Windows_NT"
   local path_sep = is_windows and "\\" or "/"
   if vim.version().minor >= 10 then
     return table.concat(vim.iter({ ... }):flatten():totable(), path_sep):gsub(path_sep .. "+", path_sep)

--- a/lua/supermaven-nvim/logger.lua
+++ b/lua/supermaven-nvim/logger.lua
@@ -1,6 +1,6 @@
 ---@diagnostic disable: missing-parameter
 local c = require("supermaven-nvim.config")
-local u = require("supermaven-nvim.util")
+local loop = vim.loop or vim.uv
 
 ---@class Log
 local log = {}
@@ -8,7 +8,7 @@ local log = {}
 ---@alias LogLevel "off" | "trace" | "debug" | "info" | "warn" | "error" | "log"
 
 local join_path = function(...)
-  local is_windows = u.uv.os_uname().version:match("Windows") -- could be "Windows" or "Windows_NT"
+  local is_windows = loop.os_uname().version:match("Windows") -- could be "Windows" or "Windows_NT"
   local path_sep = is_windows and "\\" or "/"
   if vim.version().minor >= 10 then
     return table.concat(vim.iter({ ... }):flatten():totable(), path_sep):gsub(path_sep .. "+", path_sep)

--- a/lua/supermaven-nvim/util.lua
+++ b/lua/supermaven-nvim/util.lua
@@ -229,4 +229,7 @@ M.nvim_set_option_value = function(name, value, opts)
   end
 end
 
+-- Get uv or loop depending on the version
+M.uv = vim.loop or vim.uv
+
 return M

--- a/lua/supermaven-nvim/util.lua
+++ b/lua/supermaven-nvim/util.lua
@@ -187,9 +187,9 @@ function M.to_next_word(str)
   return str
 end
 
--- Flattenning table for all versions
+-- Flattening table for all versions
 ---@param t table Table to flatten
----@param n? number Depth of the flattenning, available for version above v0.10.0
+---@param n? number Depth of the flattening, available for version above v0.10.0
 M.tbl_flatten = function(t, n)
   if n ~= nil then
     return vim.iter and vim.iter(t):flatten(n):totable() or vim.tbl_flatten(t)


### PR DESCRIPTION
@sm-victorw According to the suggestion from @Frestein in #90, I added the `deprecated api` to [`util.lua`](https://github.com/supermaven-inc/supermaven-nvim/blob/main/lua/supermaven-nvim/util.lua) along with disabling `deprecated` warning for lsp use in the file.

With these changes, if we need to use or change some `api` that is deprecated, we can do it inside. `util.lua`