### PR TITLE
fix: use correct offset_encoding

### DIFF
--- a/lua/supermaven-nvim/completion_preview.lua
+++ b/lua/supermaven-nvim/completion_preview.lua
@@ -158,7 +158,7 @@ function CompletionPreview.on_accept_suggestion(is_partial)
     vim.lsp.util.apply_text_edits(
       { { range = range, newText = completion_text } },
       vim.api.nvim_get_current_buf(),
-      "utf-16"
+      "utf-8"
     )
 
     local lines = u.line_count(completion_text)


### PR DESCRIPTION
Problem: When the current line contains specific non-ASCII characters, there's an `index out of range` error.
Cause: The `offset_encoding` is set to `utf-16` while the applied range uses `utf-8` compatible indexing.
Solution: use `utf-8` for `offset_encoding`