### PR TITLE
fix(#65): create `~/.cache/nvim` if doesn't exist

### DIFF
--- a/lua/supermaven-nvim/logger.lua
+++ b/lua/supermaven-nvim/logger.lua
@@ -21,6 +21,12 @@ local create_log_file = function()
   if log_path ~= nil then
     return
   end
+  -- If the cache directory doesn't exist, create it
+  if vim.fn.isdirectory(vim.fn.stdpath("cache")) == 0 then
+    ---@diagnostic disable-next-line: param-type-mismatch
+    vim.fn.mkdir(vim.fn.stdpath("cache"), "p")
+  end
+
   log_path = join_path(vim.fn.stdpath("cache"), "supermaven-nvim.log")
   local file = io.open(log_path, "w")
   if file == nil then

--- a/lua/supermaven-nvim/logger.lua
+++ b/lua/supermaven-nvim/logger.lua
@@ -23,8 +23,13 @@ local create_log_file = function()
   end
   -- If the cache directory doesn't exist, create it
   if vim.fn.isdirectory(vim.fn.stdpath("cache")) == 0 then
-    ---@diagnostic disable-next-line: param-type-mismatch
-    vim.fn.mkdir(vim.fn.stdpath("cache"), "p")
+    local cache_dir = vim.fn.stdpath("cache")
+    if type(cache_dir) == "string" then
+      vim.fn.mkdir(cache_dir, "p")
+    elseif type(cache_dir) == "table" then
+      cache_dir = cache_dir[1]
+      vim.fn.mkdir(cache_dir, "p")
+    end
   end
 
   log_path = join_path(vim.fn.stdpath("cache"), "supermaven-nvim.log")


### PR DESCRIPTION
This PR controls the corner case mentioned in the linked issue, creating `~/.cache/nvim` if doesn't exist.

Fixes #65