### PR TITLE
Fix inlay completions not working correctly when completion popup is open

### DIFF
--- a/lua/supermaven-nvim/completion_preview.lua
+++ b/lua/supermaven-nvim/completion_preview.lua
@@ -22,7 +22,8 @@ function CompletionPreview:render_with_inlay(
     return
   end
 
-  if vim.api.nvim_get_mode().mode ~= "i" then
+  local mode = vim.api.nvim_get_mode().mode
+  if mode ~= "i" and mode ~= "ic" then
     return
   end
 

--- a/lua/supermaven-nvim/document_listener.lua
+++ b/lua/supermaven-nvim/document_listener.lua
@@ -9,7 +9,7 @@ local M = {
 M.setup = function()
   M.augroup = vim.api.nvim_create_augroup("supermaven", { clear = true })
 
-  vim.api.nvim_create_autocmd({ "TextChanged", "TextChangedI" }, {
+  vim.api.nvim_create_autocmd({ "TextChanged", "TextChangedI", "TextChangedP" }, {
     group = M.augroup,
     callback = function(event)
       local file_name = event["file"]


### PR DESCRIPTION
There is a bug in Supermaven when using plugins that uses popup menus to display completions, e.g.: [mini.nvim#mini-completion](https://github.com/echasnovski/mini.nvim/blob/main/readmes/mini-completion.md)

When popup is open, Supermaven seem to completely stop tracking inserted text, and in turn, updating inlay completion:
![obraz](https://github.com/user-attachments/assets/84effb5b-eb21-48ed-9c04-f21418ce186a)
In this case, I typed `vim.paste` - but inlay completion is not updated with this text.


Furthermore when I accept completion with `<Tab>`:
![obraz](https://github.com/user-attachments/assets/0e5082cf-db99-4161-b304-91deb3cbe5d8)

I get `vim.pasteprint(...)` - which is not at all what completion showed - instead it seems to insert completion on top of what I already entered.

The reason for this behaviour is missing `TextChangedP` event in autocmds: when popup menu is displayed this is the event that will be triggered in Insert mode instead of regular `TextChangedI`.

Popup menus also add additional mode to `nvim_get_mode` call: when popup is displayed in insert mode, returned mode is `ic` instead of regular `i`.
