### PR TITLE
feat: add `luarocks` release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,30 @@
+name: "release"
+on:
+  push:
+    tags:
+      - "v*"
+jobs:
+  luarocks-upload:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: LuaRocks Upload
+        uses: nvim-neorocks/luarocks-tag-release@v7
+        env:
+          LUAROCKS_API_KEY: ${{ secrets.LUAROCKS_API_KEY }}
+        with:
+          summary: "The official Neovim plugin for Supermaven"
+          detailed_description: |
+            The official Neovim plugin for Supermaven.
+
+            This plugin provides code suggestions using Supermaven's AI assistant.
+          template: "./rockspec.template"
+          labels: |
+            neovim-plugin
+            lua
+            nvim
+            neovim
+            nvim-plugin
+            supermaven
+            ai
+          license: "MIT"

--- a/rockspec.template
+++ b/rockspec.template
@@ -1,0 +1,30 @@
+local git_tag = "$git_tag"
+local modrev = "$modrev"
+local specrev = "-1"
+
+local repo_url = "$repo_url"
+
+rockspec_format = "3.0"
+package = "$package"
+version = modrev .. specrev
+
+description = {
+  summary = "$summary",
+  detailed = $detailed_description,
+  labels = $labels,
+  homepage = "$homepage",
+  $license
+}
+
+dependencies = {
+  "lua >= 5.1, < 5.4",
+}
+
+source = {
+  url = repo_url .. "/archive/" .. git_tag .. ".zip",
+  dir = "$repo_name-" .. modrev,
+}
+
+build = {
+  type = "builtin",
+}

--- a/supermaven-nvim-scm-1.rockspec
+++ b/supermaven-nvim-scm-1.rockspec
@@ -1,0 +1,29 @@
+local _MODREV, _SPECREV = "scm", "-1"
+
+rockspec_format = "3.0"
+package = "supermaven-nvim"
+version = _MODREV .. _SPECREV
+
+description = {
+  summary = "The official Neovim plugin for Supermaven",
+  detailed = [[
+    The official Neovim plugin for Supermaven.
+
+    This plugin provides code suggestions using Supermaven's AI assistant.
+  ]],
+  homepage = "https://github.com/supermaven-inc/supermaven-nvim",
+  license = "MIT",
+}
+
+source = {
+  url = "git+https://github.com/supermaven-inc/supermaven-nvim.git",
+  tag = _MODREV .. _SPECREV,
+}
+
+dependencies = {
+  "lua >= 5.1 < 5.4",
+}
+
+build = {
+  type = "builtin",
+}


### PR DESCRIPTION
With this PR it publishes the plugin on <https://luarocks.org/> to make it available on [rocks.nvim](https://github.com/nvim-neorocks/rocks.nvim).

I made it so it publishes when pushing on tags (v*) i.e. v0.1.0. This can be changed to publish on a different kind of versioning we want to keep see [luarocks-tag-release docs](https://github.com/nvim-neorocks/luarocks-tag-release?tab=readme-ov-file#version-optional) for more information.

Closes #104