### PR TITLE
support SUPERMAVEN_BINARY environment variable

### DIFF
--- a/lua/supermaven-nvim/binary/binary_fetcher.lua
+++ b/lua/supermaven-nvim/binary/binary_fetcher.lua
@@ -129,7 +129,9 @@ function BinaryFetcher:fetch_binary()
 end
 
 function BinaryFetcher:local_binary_path()
-  if self:platform() == "windows" then
+  if vim.env.SUPERMAVEN_BINARY ~= nil then
+    return vim.env.SUPERMAVEN_BINARY
+  elseif self:platform() == "windows" then
     return self:local_binary_parent_path() .. "/sm-agent.exe"
   else
     return self:local_binary_parent_path() .. "/sm-agent"


### PR DESCRIPTION
This is a variation of [my patch](https://github.com/mrshmllow/nvim-candy/blob/main/patches/use-env-for-supermaven-binary-path.patch) which ive been using for a while

It makes this plugin nicer to use in environments like nix where you can provide this binary deterministically to the plugin before hand. Like I do [here](https://github.com/mrshmllow/nvim-candy/blob/main/flake.nix#L125)