### PR TITLE
Allow disable_inline_completion to be a function

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,21 @@ require("supermaven-nvim").setup({
 
 This will disable supermaven-nvim for files with the name `foo.sh` in it, e.g. `myscriptfoo.sh`.
 
+
+To disable inline completion temporarily, you can pass a function to `disable_inline_completion` that returns `true` when you want to disable inline completion. 
+For example:
+
+```lua
+require("supermaven-nvim").setup({
+  disable_inline_completion = function()
+    return require("cmp").visible()
+  end
+})
+```
+
+This will disable inline completion when the completion menu of nvim-cmp is visible.
+
+
 ### Using with nvim-cmp
 
 If you are using nvim-cmp, you can use the `supermaven` source (which is registered by default) by adding the following to your `cmp.setup()` function:

--- a/lua/supermaven-nvim/completion_preview.lua
+++ b/lua/supermaven-nvim/completion_preview.lua
@@ -57,8 +57,13 @@ function CompletionPreview:render_with_inlay(
   self.inlay_instance = new_instance
 end
 
+function CompletionPreview:is_inline_completion_disabled()
+  local disable_inline = self.disable_inline_completion or false
+  return disable_inline == true or (type(disable_inline) == "function" and disable_inline())
+end
+
 function CompletionPreview:render_floating(first_line, opts, buf, line_before_cursor)
-  if self.disable_inline_completion then
+  if self:is_inline_completion_disabled() then
     return
   end
 
@@ -72,7 +77,7 @@ function CompletionPreview:render_floating(first_line, opts, buf, line_before_cu
 end
 
 function CompletionPreview:render_standard(first_line, other_lines, opts, buf)
-  if self.disable_inline_completion then
+  if self:is_inline_completion_disabled() then
     return
   end
 

--- a/lua/supermaven-nvim/init.lua
+++ b/lua/supermaven-nvim/init.lua
@@ -9,9 +9,9 @@ local M = {}
 M.setup = function(args)
   config.setup(args)
 
-  if config.disable_inline_completion then
-    completion_preview.disable_inline_completion = true
-  elseif not config.disable_keymaps then
+  completion_preview.disable_inline_completion = config.disable_inline_completion
+
+  if config.disable_inline_completion ~= true and not config.disable_keymaps then
     if config.keymaps.accept_suggestion ~= nil then
       local accept_suggestion_key = config.keymaps.accept_suggestion
       vim.keymap.set(
@@ -45,7 +45,7 @@ M.setup = function(args)
     local cmp_source = require("supermaven-nvim.cmp")
     cmp.register_source("supermaven", cmp_source.new())
   else
-    if config.disable_inline_completion then
+    if config.disable_inline_completion == true then
       log:warn(
         "nvim-cmp is not available, but inline completion is disabled. Supermaven nvim-cmp source will not be registered."
       )


### PR DESCRIPTION
Inline completions can be disabled per buffer, but sometimes you want to disable supermaven only temporarily.
This change allows `disable_inline_completion` to be a function in addition to a boolean, adding more flexibility.

A possible setup:
Supermaven is on by default. But when cmp-nvim is triggered via shortcut, it is disabled to avoid suggestions mess.
