### PR TITLE
feat: Allow calling setup again to change configuration

### DIFF
--- a/lua/supermaven-nvim/config.lua
+++ b/lua/supermaven-nvim/config.lua
@@ -18,7 +18,7 @@ local M = {
 }
 
 M.setup = function(args)
-  M.config = vim.tbl_deep_extend("force", vim.deepcopy(default_config), args)
+  M.config = vim.tbl_deep_extend("force", M.config, args)
 end
 
 return setmetatable(M, {

--- a/lua/supermaven-nvim/init.lua
+++ b/lua/supermaven-nvim/init.lua
@@ -6,12 +6,34 @@ local api = require("supermaven-nvim.api")
 
 local M = {}
 
+local first_time_setup = true
+
 M.setup = function(args)
+
+  -- Remove old keymaps
+  if not first_time_setup and not config.disable_inline_completion and not config.disable_keymaps then
+    if config.keymaps.accept_suggestion ~= nil then
+      local accept_suggestion_key = config.keymaps.accept_suggestion
+      vim.keymap.del("i", accept_suggestion_key)
+    end
+
+    if config.keymaps.accept_word ~= nil then
+      local accept_word_key = config.keymaps.accept_word
+      vim.keymap.del("i", accept_word_key)
+    end
+
+    if config.keymaps.clear_suggestion ~= nil then
+      local clear_suggestion_key = config.keymaps.clear_suggestion
+      vim.keymap.del("i", clear_suggestion_key)
+    end
+  end
+
   config.setup(args)
 
-  if config.disable_inline_completion then
-    completion_preview.disable_inline_completion = true
-  elseif not config.disable_keymaps then
+  completion_preview.disable_inline_completion = config.disable_inline_completion
+
+  -- Add new keymaps
+  if not config.disable_inline_completion and not config.disable_keymaps then
     if config.keymaps.accept_suggestion ~= nil then
       local accept_suggestion_key = config.keymaps.accept_suggestion
       vim.keymap.set(
@@ -38,21 +60,25 @@ M.setup = function(args)
     end
   end
 
-  commands.setup()
+  if first_time_setup then
+    first_time_setup = false
 
-  local cmp_ok, cmp = pcall(require, "cmp")
-  if cmp_ok then
-    local cmp_source = require("supermaven-nvim.cmp")
-    cmp.register_source("supermaven", cmp_source.new())
-  else
-    if config.disable_inline_completion then
-      log:warn(
-        "nvim-cmp is not available, but inline completion is disabled. Supermaven nvim-cmp source will not be registered."
-      )
+    commands.setup()
+
+    local cmp_ok, cmp = pcall(require, "cmp")
+    if cmp_ok then
+      local cmp_source = require("supermaven-nvim.cmp")
+      cmp.register_source("supermaven", cmp_source.new())
+    else
+      if config.disable_inline_completion then
+        log:warn(
+          "nvim-cmp is not available, but inline completion is disabled. Supermaven nvim-cmp source will not be registered."
+        )
+      end
     end
-  end
 
-  api.start()
+    api.start()
+  end
 end
 
 return M

--- a/lua/supermaven-nvim/init.lua
+++ b/lua/supermaven-nvim/init.lua
@@ -61,8 +61,6 @@ M.setup = function(args)
   end
 
   if first_time_setup then
-    first_time_setup = false
-
     commands.setup()
 
     local cmp_ok, cmp = pcall(require, "cmp")
@@ -78,6 +76,8 @@ M.setup = function(args)
     end
 
     api.start()
+
+    first_time_setup = false
   end
 end
 


### PR DESCRIPTION
This PR adds the ability to call `setup` again with a different configuration. The use case that prompted this was wanting a way to toggle between using supermaven with `cmp` or with inline completion.

(For the curious, this is how I'm able to achieve this:)

``` lua
local function toggle_cmp_or_supermaven()
    local cmp = require('cmp')
    local supermaven = require('supermaven-nvim')
    local current_setting = cmp.get_config().completion.autocomplete
    if current_setting and #current_setting > 0 then
        cmp.setup({ completion = { autocomplete = false } })
        supermaven.setup({
            disable_inline_completion = false,
        })
    else
        cmp.setup({ completion = { autocomplete = { cmp.TriggerEvent.TextChanged } } })
        supermaven.setup({
            disable_inline_completion = true,
        })
    end
end

vim.api.nvim_create_user_command('CmpSupermavenToggle', toggle_cmp_or_supermaven, {})
```