### PR TITLE
Added some new options for single line completion previews.

### DIFF
--- a/lua/supermaven-nvim/config.lua
+++ b/lua/supermaven-nvim/config.lua
@@ -7,6 +7,8 @@ local default_config = {
   ignore_filetypes = {},
   disable_inline_completion = false,
   disable_keymaps = false,
+  single_line_suggestion_newline = false,
+  show_diff_only = false,
   condition = function()
     return false
   end,

--- a/lua/supermaven-nvim/init.lua
+++ b/lua/supermaven-nvim/init.lua
@@ -37,8 +37,9 @@ M.setup = function(args)
       vim.keymap.set("i", clear_suggestion_key, completion_preview.on_dispose_inlay, { noremap = true, silent = true })
     end
   end
-
   commands.setup()
+  completion_preview.single_line_suggestion_newline = config.single_line_suggestion_newline
+  completion_preview.show_diff_only = config.show_diff_only
 
   local cmp_ok, cmp = pcall(require, "cmp")
   if cmp_ok then


### PR DESCRIPTION
This pull request addresses the following issues.

https://github.com/supermaven-inc/supermaven-nvim/issues/66
https://github.com/supermaven-inc/supermaven-nvim/issues/69
https://github.com/supermaven-inc/supermaven-nvim/issues/80

The two new options render all single line completions on a new virtual line, just like multi-line completions. 
The show_diff_only option pads the suggestion with whitespace instead of the existing text. 

![supermaven](https://github.com/user-attachments/assets/46b6d938-0a6f-425d-80d3-f2be3c9d2ab1)
![supermaven2](https://github.com/user-attachments/assets/031cfdd9-9e95-4a5c-88f8-e033db1fc897)