### PR TITLE
Fix disabling supermaven-nvim conditionally

### DIFF
--- a/lua/supermaven-nvim/binary/binary_handler.lua
+++ b/lua/supermaven-nvim/binary/binary_handler.lua
@@ -81,7 +81,8 @@ end
 ---@param file_name string
 ---@param event_type "text_changed" | "cursor"
 function BinaryLifecycle:on_update(buffer, file_name, event_type)
-  if config.ignore_filetypes[vim.bo.ft] or config.condition() or or vim.tbl_contains(config.ignore_filetypes, vim.bo.filetype) then
+
+  if config.ignore_filetypes[vim.bo.ft] or config.condition() or vim.tbl_contains(config.ignore_filetypes, vim.bo.filetype) then
     return
   end
   local buffer_text = u.get_text(buffer)

--- a/lua/supermaven-nvim/binary/binary_handler.lua
+++ b/lua/supermaven-nvim/binary/binary_handler.lua
@@ -81,7 +81,7 @@ end
 ---@param file_name string
 ---@param event_type "text_changed" | "cursor"
 function BinaryLifecycle:on_update(buffer, file_name, event_type)
-  if config.ignore_filetypes[vim.bo.ft] or vim.tbl_contains(config.ignore_filetypes, vim.bo.filetype) then
+  if config.ignore_filetypes[vim.bo.ft] or config.condition() or or vim.tbl_contains(config.ignore_filetypes, vim.bo.filetype) then
     return
   end
   local buffer_text = u.get_text(buffer)
@@ -268,7 +268,7 @@ function BinaryLifecycle:provide_inline_completion_items(buffer, cursor, context
 end
 
 function BinaryLifecycle:poll_once()
-  if config.ignore_filetypes[vim.bo.ft] or vim.tbl_contains(config.ignore_filetypes, vim.bo.filetype) then
+  if config.ignore_filetypes[vim.bo.ft] or config.condition() or vim.tbl_contains(config.ignore_filetypes, vim.bo.filetype) then
     return
   end
   local now = loop.now()

--- a/lua/supermaven-nvim/document_listener.lua
+++ b/lua/supermaven-nvim/document_listener.lua
@@ -27,7 +27,7 @@ M.setup = function()
       if not ok then
         return
       end
-      if config.condition() or vim.g.SUPERMAVEN_DISABLED == 1 then
+      if  vim.g.SUPERMAVEN_DISABLED == 1 then
         if api.is_running() then
           api.stop()
           return


### PR DESCRIPTION
For context I'm using the conditional mechanism to keep supermaven disabled by default and only enabled for specific filetypes (there is no other way to achieve this currently). 

The way the `condition` feature is described in the README leads me to suggest that to accomplish this "default off" behaviour I should be able to use this mechanism. 

The original code will basically shut down supermaven completely whenever the `condition` function is evaluated to false, this becomes a problem if you have multiple files open in the same neovim session, as soon as you open one which has a false `condition` then immediately supermaven is shut down for all other files. 

This PR fixes this issue by using the `condition` in much the same way that the `ignore_filetypes` is used. 