### PR TITLE
fix: virtual text on wrapped/long lines

### DIFF
--- a/lua/supermaven-nvim/completion_preview.lua
+++ b/lua/supermaven-nvim/completion_preview.lua
@@ -83,9 +83,12 @@ function CompletionPreview:render_standard(first_line, other_lines, opts, buf)
     opts.virt_lines = other_lines
   end
 
-  opts.virt_text_win_col = vim.fn.virtcol(".") - 1
+  opts.virt_text_pos = "overlay"
+  local pos = vim.api.nvim_win_get_cursor(0)
+  local row = pos[1] - 1
+  local col = pos[2]
 
-  local _extmark_id = vim.api.nvim_buf_set_extmark(buf, self.ns_id, vim.fn.line(".") - 1, vim.fn.col(".") - 1, opts) -- :h api-extended-marks
+  local _extmark_id = vim.api.nvim_buf_set_extmark(buf, self.ns_id, row, col, opts) -- :h api-extended-marks
 end
 
 function CompletionPreview:dispose_inlay()


### PR DESCRIPTION
The existing position calculation for virtual text in `CompletionPreview:render_standard(...)` fails when lines are longer than the width of the window (i.e. the screen starts scrolling horizontally with nowrap, or when the line wraps). Currently, when this happens, the virtual text is simply rendered outside of the screen and can not be seen.

This PR fixes the issue by using the cursor position rather than the position returned by `virtcol(".")`.
This enables virtual text to actually be visible when lines are long.