### PR TITLE
Add support for MSYS2

### DIFF
--- a/lua/supermaven-nvim/binary/binary_fetcher.lua
+++ b/lua/supermaven-nvim/binary/binary_fetcher.lua
@@ -26,12 +26,10 @@ function BinaryFetcher:platform()
   local os = self.os_uname.sysname
   if os == "Darwin" then
     return "macosx"
-  elseif os == "Linux" then
-    return "linux"
-  elseif os == "Windows_NT" then
+  elseif os == "Windows_NT" or os:match("MINGW") then
     return "windows"
   end
-  return ""
+  return "linux"
 end
 
 function BinaryFetcher:get_arch()


### PR DESCRIPTION
Encountered issues trying to run this in MSYS2. Fixed it by adding MINGW to the environments.
Also removed the check for linux and made it the default.